### PR TITLE
Add frame block width dropdown and square rendering

### DIFF
--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -167,6 +167,7 @@ bool uv_viewer_update_pipeline(UvViewer *viewer, const UvPipelineOverrides *over
 void uv_viewer_frame_block_configure(UvViewer *viewer, gboolean enabled, gboolean snapshot_mode);
 void uv_viewer_frame_block_pause(UvViewer *viewer, gboolean paused);
 void uv_viewer_frame_block_reset(UvViewer *viewer);
+void uv_viewer_frame_block_set_width(UvViewer *viewer, guint width);
 void uv_viewer_frame_block_set_thresholds(UvViewer *viewer,
                                           double green_ms,
                                           double yellow_ms,

--- a/src/relay_controller.c
+++ b/src/relay_controller.c
@@ -9,7 +9,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#define UV_FRAME_BLOCK_DEFAULT_WIDTH  100u
+#define UV_FRAME_BLOCK_DEFAULT_WIDTH   60u
 #define UV_FRAME_BLOCK_DEFAULT_HEIGHT 100u
 #define UV_FRAME_BLOCK_COLOR_BUCKETS  4u
 #define UV_FRAME_BLOCK_DEFAULT_SIZE_GREEN_KB  64.0
@@ -910,6 +910,32 @@ void relay_controller_frame_block_configure(RelayController *rc, gboolean enable
         src->frame_block_accum_bytes = 0;
     }
     rc->frame_block.reset_requested = FALSE;
+    g_mutex_unlock(&rc->lock);
+}
+
+void relay_controller_frame_block_set_width(RelayController *rc, guint width) {
+    if (!rc) return;
+    guint clamped = MAX(width, 1u);
+
+    g_mutex_lock(&rc->lock);
+    if (rc->frame_block.width == clamped) {
+        g_mutex_unlock(&rc->lock);
+        return;
+    }
+
+    rc->frame_block.width = clamped;
+    guint height = rc->frame_block.height ? rc->frame_block.height : UV_FRAME_BLOCK_DEFAULT_HEIGHT;
+
+    for (guint i = 0; i < rc->sources_count; i++) {
+        UvRelaySource *src = &rc->sources[i];
+        if (!src->frame_block) continue;
+        UvFrameBlockState *old_state = src->frame_block;
+        src->frame_block = frame_block_state_new(rc->frame_block.width, height);
+        frame_block_state_apply_lateness_thresholds(src->frame_block, rc->frame_block.thresholds_ms);
+        frame_block_state_apply_size_thresholds(src->frame_block, rc->frame_block.thresholds_kb);
+        frame_block_state_free(old_state);
+    }
+
     g_mutex_unlock(&rc->lock);
 }
 

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -199,6 +199,7 @@ void     relay_controller_set_push_enabled(RelayController *rc, gboolean enabled
 void     relay_controller_frame_block_configure(RelayController *rc, gboolean enabled, gboolean snapshot_mode);
 void     relay_controller_frame_block_pause(RelayController *rc, gboolean paused);
 void     relay_controller_frame_block_reset(RelayController *rc);
+void     relay_controller_frame_block_set_width(RelayController *rc, guint width);
 void     relay_controller_frame_block_set_thresholds(RelayController *rc,
                                                      double green_ms,
                                                      double yellow_ms,

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -150,6 +150,11 @@ void uv_viewer_frame_block_reset(UvViewer *viewer) {
     relay_controller_frame_block_reset(&viewer->relay);
 }
 
+void uv_viewer_frame_block_set_width(UvViewer *viewer, guint width) {
+    if (!viewer) return;
+    relay_controller_frame_block_set_width(&viewer->relay, width);
+}
+
 void uv_viewer_frame_block_set_thresholds(UvViewer *viewer,
                                           double green_ms,
                                           double yellow_ms,


### PR DESCRIPTION
## Summary
- add a dropdown to choose frame block row widths with a 60-cell default and reset handling
- render frame block cells with a square aspect ratio for consistent visualization
- expose a frame block width setter through the viewer API and relay controller

## Testing
- make *(fails: missing gtk4/gstreamer development packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dab9f03fa0832b8e2a275255494dcb