### PR TITLE
Add GUI and pipeline support for selecting video sink

### DIFF
--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -20,6 +20,16 @@ typedef enum {
     UV_DECODER_SOFTWARE
 } UvDecoderPreference;
 
+typedef enum {
+    UV_VIDEO_SINK_AUTO = 0,
+    UV_VIDEO_SINK_GTK4,
+    UV_VIDEO_SINK_WAYLAND,
+    UV_VIDEO_SINK_GLIMAGE,
+    UV_VIDEO_SINK_XVIMAGE,
+    UV_VIDEO_SINK_AUTOVIDEO,
+    UV_VIDEO_SINK_FAKESINK
+} UvVideoSinkPreference;
+
 typedef struct {
     int listen_port;   // UDP port to bind (default: 5600)
     int payload_type;  // RTP payload type (default: 97)
@@ -39,6 +49,7 @@ typedef struct {
     guint audio_clock_rate; // RTP clock rate for audio (default: 48000)
     guint audio_jitter_latency_ms; // jitter buffer latency for audio (default: 8)
     UvDecoderPreference decoder_preference;
+    UvVideoSinkPreference video_sink_preference;
 } UvViewerConfig;
 
 typedef struct {

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -41,6 +41,7 @@ typedef struct {
     GtkSpinButton *queue_max_buffers_spin;
     GtkSpinButton *stats_refresh_spin;
     GtkDropDown *decoder_dropdown;
+    GtkDropDown *sink_dropdown;
     GtkCheckButton *videorate_toggle;
     GtkSpinButton *videorate_num_spin;
     GtkSpinButton *videorate_den_spin;
@@ -196,6 +197,43 @@ static UvDecoderPreference decoder_index_to_pref(guint index) {
         case 4:  return UV_DECODER_SOFTWARE;
         case 0:
         default: return UV_DECODER_AUTO;
+    }
+}
+
+static const char *video_sink_option_labels[] = {
+    "Auto",
+    "GTK4 Paintable",
+    "Wayland",
+    "GL Image",
+    "XVideo",
+    "Auto Video",
+    "Fakesink",
+    NULL
+};
+
+static guint video_sink_pref_to_index(UvVideoSinkPreference pref) {
+    switch (pref) {
+        case UV_VIDEO_SINK_GTK4:      return 1u;
+        case UV_VIDEO_SINK_WAYLAND:   return 2u;
+        case UV_VIDEO_SINK_GLIMAGE:   return 3u;
+        case UV_VIDEO_SINK_XVIMAGE:   return 4u;
+        case UV_VIDEO_SINK_AUTOVIDEO: return 5u;
+        case UV_VIDEO_SINK_FAKESINK:  return 6u;
+        case UV_VIDEO_SINK_AUTO:
+        default:                      return 0u;
+    }
+}
+
+static UvVideoSinkPreference video_sink_index_to_pref(guint index) {
+    switch (index) {
+        case 1: return UV_VIDEO_SINK_GTK4;
+        case 2: return UV_VIDEO_SINK_WAYLAND;
+        case 3: return UV_VIDEO_SINK_GLIMAGE;
+        case 4: return UV_VIDEO_SINK_XVIMAGE;
+        case 5: return UV_VIDEO_SINK_AUTOVIDEO;
+        case 6: return UV_VIDEO_SINK_FAKESINK;
+        case 0:
+        default: return UV_VIDEO_SINK_AUTO;
     }
 }
 
@@ -860,9 +898,11 @@ static void update_info_label(GuiContext *ctx) {
     }
     const char *decoder_pref = decoder_option_labels[decoder_pref_to_index(cfg->decoder_preference)];
     if (!decoder_pref) decoder_pref = "Auto";
+    const char *sink_pref = video_sink_option_labels[video_sink_pref_to_index(cfg->video_sink_preference)];
+    if (!sink_pref) sink_pref = "Auto";
     g_snprintf(info, sizeof(info),
                "Listening on %d | PT %d | Clock %d | %s | Jitter %ums | Queue buffers %u"
-               " | drop=%s | lost=%s | bus-msg=%s | videorate=%s | decoder=%s | audio=%s",
+               " | drop=%s | lost=%s | bus-msg=%s | videorate=%s | decoder=%s | sink=%s | audio=%s",
                cfg->listen_port,
                cfg->payload_type,
                cfg->clock_rate,
@@ -874,6 +914,7 @@ static void update_info_label(GuiContext *ctx) {
                cfg->jitter_post_drop_messages ? "on" : "off",
                videorate_info,
                decoder_pref,
+               sink_pref,
                audio_state);
     gtk_label_set_text(ctx->info_label, info);
 }
@@ -895,6 +936,10 @@ static void sync_settings_controls(GuiContext *ctx) {
     if (ctx->decoder_dropdown) {
         gtk_drop_down_set_selected(ctx->decoder_dropdown,
                                    decoder_pref_to_index(ctx->current_cfg.decoder_preference));
+    }
+    if (ctx->sink_dropdown) {
+        gtk_drop_down_set_selected(ctx->sink_dropdown,
+                                   video_sink_pref_to_index(ctx->current_cfg.video_sink_preference));
     }
     if (ctx->videorate_toggle) {
         check_set(ctx->videorate_toggle, ctx->current_cfg.videorate_enabled);
@@ -1522,6 +1567,7 @@ static gboolean gui_restart_with_config(GuiContext *ctx, const UvViewerConfig *c
         cfg->videorate_fps_numerator == ctx->current_cfg.videorate_fps_numerator &&
         cfg->videorate_fps_denominator == ctx->current_cfg.videorate_fps_denominator &&
         cfg->decoder_preference == ctx->current_cfg.decoder_preference &&
+        cfg->video_sink_preference == ctx->current_cfg.video_sink_preference &&
         cfg->audio_enabled == ctx->current_cfg.audio_enabled &&
         cfg->audio_payload_type == ctx->current_cfg.audio_payload_type &&
         cfg->audio_clock_rate == ctx->current_cfg.audio_clock_rate &&
@@ -1658,6 +1704,13 @@ static void on_settings_apply_clicked(GtkButton *button, gpointer user_data) {
             decoder_idx = decoder_pref_to_index(ctx->current_cfg.decoder_preference);
         }
         new_cfg.decoder_preference = decoder_index_to_pref(decoder_idx);
+    }
+    if (ctx->sink_dropdown) {
+        guint sink_idx = gtk_drop_down_get_selected(ctx->sink_dropdown);
+        if (sink_idx == GTK_INVALID_LIST_POSITION) {
+            sink_idx = video_sink_pref_to_index(ctx->current_cfg.video_sink_preference);
+        }
+        new_cfg.video_sink_preference = video_sink_index_to_pref(sink_idx);
     }
 
     if (!gui_restart_with_config(ctx, &new_cfg)) {
@@ -1940,12 +1993,21 @@ static GtkWidget *build_settings_page(GuiContext *ctx) {
                                decoder_pref_to_index(ctx->current_cfg.decoder_preference));
     gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->decoder_dropdown), 1, 5, 1, 1);
 
+    GtkWidget *sink_label = gtk_label_new("Video Sink:");
+    gtk_label_set_xalign(GTK_LABEL(sink_label), 0.0);
+    gtk_grid_attach(GTK_GRID(grid), sink_label, 0, 6, 1, 1);
+
+    ctx->sink_dropdown = GTK_DROP_DOWN(gtk_drop_down_new_from_strings(video_sink_option_labels));
+    gtk_drop_down_set_selected(ctx->sink_dropdown,
+                               video_sink_pref_to_index(ctx->current_cfg.video_sink_preference));
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->sink_dropdown), 1, 6, 1, 1);
+
     GtkWidget *videorate_label = gtk_label_new("Videorate:");
     gtk_label_set_xalign(GTK_LABEL(videorate_label), 0.0);
-    gtk_grid_attach(GTK_GRID(grid), videorate_label, 0, 6, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), videorate_label, 0, 7, 1, 1);
 
     GtkWidget *videorate_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-    gtk_grid_attach(GTK_GRID(grid), videorate_box, 1, 6, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), videorate_box, 1, 7, 1, 1);
 
     ctx->videorate_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Enable"));
     gtk_box_append(GTK_BOX(videorate_box), GTK_WIDGET(ctx->videorate_toggle));
@@ -1966,10 +2028,10 @@ static GtkWidget *build_settings_page(GuiContext *ctx) {
 
     GtkWidget *audio_label = gtk_label_new("Audio:");
     gtk_label_set_xalign(GTK_LABEL(audio_label), 0.0);
-    gtk_grid_attach(GTK_GRID(grid), audio_label, 0, 7, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), audio_label, 0, 8, 1, 1);
 
     GtkWidget *audio_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-    gtk_grid_attach(GTK_GRID(grid), audio_box, 1, 7, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), audio_box, 1, 8, 1, 1);
 
     ctx->audio_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Enable"));
     gtk_box_append(GTK_BOX(audio_box), GTK_WIDGET(ctx->audio_toggle));
@@ -1990,13 +2052,13 @@ static GtkWidget *build_settings_page(GuiContext *ctx) {
     gtk_box_append(GTK_BOX(audio_box), GTK_WIDGET(ctx->audio_jitter_spin));
 
     ctx->jitter_drop_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Drop packets exceeding latency"));
-    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_drop_toggle), 0, 8, 2, 1);
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_drop_toggle), 0, 9, 2, 1);
 
     ctx->jitter_do_lost_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Emit lost packet notifications"));
-    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_do_lost_toggle), 0, 9, 2, 1);
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_do_lost_toggle), 0, 10, 2, 1);
 
     ctx->jitter_post_drop_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Post drop messages on bus"));
-    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_post_drop_toggle), 0, 10, 2, 1);
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->jitter_post_drop_toggle), 0, 11, 2, 1);
 
     GtkWidget *apply_button = gtk_button_new_with_label("Apply Settings");
     g_signal_connect(apply_button, "clicked", G_CALLBACK(on_settings_apply_clicked), ctx);
@@ -2472,6 +2534,7 @@ static void on_app_shutdown(GApplication *app, gpointer user_data) {
     ctx->queue_max_buffers_spin = NULL;
     ctx->stats_refresh_spin = NULL;
     ctx->decoder_dropdown = NULL;
+    ctx->sink_dropdown = NULL;
     ctx->videorate_toggle = NULL;
     ctx->videorate_num_spin = NULL;
     ctx->videorate_den_spin = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,8 @@ static void print_usage(const char *argv0) {
     g_printerr("Usage: %s [--listen-port N] [--payload PT] [--clockrate Hz] [--sync|--no-sync]"
                " [--videorate] [--no-videorate] [--videorate-fps NUM[/DEN]]"
                " [--audio] [--no-audio] [--audio-payload PT] [--audio-clockrate Hz]"
-               " [--audio-jitter ms] [--decoder auto|intel|nvidia|vaapi|software]\n",
+               " [--audio-jitter ms] [--decoder auto|intel|nvidia|vaapi|software]"
+               " [--video-sink auto|gtk4|wayland|gl|xv|autovideo|fakesink]\n",
                argv0);
 }
 
@@ -32,6 +33,48 @@ static gboolean parse_decoder_option(const char *value, UvViewerConfig *cfg) {
     }
     if (g_ascii_strcasecmp(value, "software") == 0 || g_ascii_strcasecmp(value, "cpu") == 0) {
         cfg->decoder_preference = UV_DECODER_SOFTWARE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean parse_video_sink_option(const char *value, UvViewerConfig *cfg) {
+    if (!value || !cfg) return FALSE;
+    if (g_ascii_strcasecmp(value, "auto") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_AUTO;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "gtk4") == 0 ||
+        g_ascii_strcasecmp(value, "gtk4paintable") == 0 ||
+        g_ascii_strcasecmp(value, "gtk") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_GTK4;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "wayland") == 0 ||
+        g_ascii_strcasecmp(value, "waylandsink") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_WAYLAND;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "gl") == 0 ||
+        g_ascii_strcasecmp(value, "glimage") == 0 ||
+        g_ascii_strcasecmp(value, "glimagesink") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_GLIMAGE;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "xv") == 0 ||
+        g_ascii_strcasecmp(value, "xvimage") == 0 ||
+        g_ascii_strcasecmp(value, "xvimagesink") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_XVIMAGE;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "autovideo") == 0 ||
+        g_ascii_strcasecmp(value, "autovideosink") == 0 ||
+        g_ascii_strcasecmp(value, "auto-video") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_AUTOVIDEO;
+        return TRUE;
+    }
+    if (g_ascii_strcasecmp(value, "fakesink") == 0) {
+        cfg->video_sink_preference = UV_VIDEO_SINK_FAKESINK;
         return TRUE;
     }
     return FALSE;
@@ -101,6 +144,12 @@ static gboolean parse_args(int argc, char **argv, UvViewerConfig *cfg) {
             const char *choice = argv[++i];
             if (!parse_decoder_option(choice, cfg)) {
                 g_printerr("Unknown decoder option: %s\n", choice);
+                return FALSE;
+            }
+        } else if (!strcmp(argv[i], "--video-sink") && i + 1 < argc) {
+            const char *sink_choice = argv[++i];
+            if (!parse_video_sink_option(sink_choice, cfg)) {
+                g_printerr("Unknown video sink option: %s\n", sink_choice);
                 return FALSE;
             }
         } else if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -114,6 +114,7 @@ typedef struct {
     guint videorate_fps_num;
     guint videorate_fps_den;
     UvDecoderPreference decoder_preference;
+    UvVideoSinkPreference video_sink_preference;
     gboolean audio_enabled;
     guint audio_payload_type;
     guint audio_clock_rate;
@@ -155,6 +156,8 @@ typedef struct {
     guint bus_watch_id;
     gulong decoder_probe_id;
     gboolean sink_is_fakesink;
+    GPtrArray *sink_factories;
+    guint sink_factory_index;
     gulong audio_probe_id;
     gboolean audio_sink_is_fakesink;
     gint64 audio_last_buffer_us;

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -33,6 +33,7 @@ void uv_viewer_config_init(UvViewerConfig *cfg) {
     cfg->audio_clock_rate = 48000;
     cfg->audio_jitter_latency_ms = 8;
     cfg->decoder_preference = UV_DECODER_AUTO;
+    cfg->video_sink_preference = UV_VIDEO_SINK_AUTO;
 }
 
 UvViewer *uv_viewer_new(const UvViewerConfig *cfg) {


### PR DESCRIPTION
## Summary
- add a video sink preference to the viewer config and pipeline so forced sinks are tried before fallbacks
- expose the sink preference via CLI and the settings dropdown alongside the decoder selector

## Testing
- make *(fails: missing gstreamer/gtk dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db550bdc10832b910d3e217f0f51a4