### PR TITLE
Support multiple UDP listen ports

### DIFF
--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -9,6 +9,7 @@
 G_BEGIN_DECLS
 
 #define UV_VIEWER_ADDR_MAX 64
+#define UV_VIEWER_MAX_EXTRA_LISTEN_PORTS 8
 
 typedef struct _UvViewer UvViewer;
 
@@ -31,7 +32,9 @@ typedef enum {
 } UvVideoSinkPreference;
 
 typedef struct {
-    int listen_port;   // UDP port to bind (default: 5600)
+    int listen_port;   // Primary UDP port to bind (default: 5600)
+    guint extra_listen_port_count; // number of additional ports in extra_listen_ports
+    int extra_listen_ports[UV_VIEWER_MAX_EXTRA_LISTEN_PORTS];
     int payload_type;  // RTP payload type (default: 97)
     int clock_rate;    // RTP clock rate (default: 90000)
     bool sync_to_clock; // TRUE to let sink sync to clock

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -21,6 +21,7 @@ typedef struct {
     struct sockaddr_in addr;
     socklen_t addrlen;
     bool in_use;
+    uint16_t local_port;
 
     uint64_t rx_packets;
     uint64_t rx_bytes;
@@ -51,6 +52,8 @@ typedef struct {
 
 typedef struct {
     int listen_port;
+    guint extra_listen_port_count;
+    int extra_listen_ports[UV_VIEWER_MAX_EXTRA_LISTEN_PORTS];
     GThread *thread;
     volatile sig_atomic_t running;
     volatile sig_atomic_t push_enabled;

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -16,6 +16,10 @@ static void uv_viewer_init_struct(UvViewer *viewer, const UvViewerConfig *cfg) {
 void uv_viewer_config_init(UvViewerConfig *cfg) {
     if (!cfg) return;
     cfg->listen_port = 5600;
+    cfg->extra_listen_port_count = 0;
+    for (guint i = 0; i < UV_VIEWER_MAX_EXTRA_LISTEN_PORTS; i++) {
+        cfg->extra_listen_ports[i] = 0;
+    }
     cfg->payload_type = 97;
     cfg->clock_rate = 90000;
     cfg->sync_to_clock = FALSE;


### PR DESCRIPTION
## Summary
- allow the relay to bind and poll multiple UDP listen ports while tracking the local port per source
- add a GTK settings field for session-scoped additional ports and include the active port list in status displays
- extend the CLI and stats formatting to show local ports and accept repeated --listen-extra-port flags

## Testing
- make *(fails: missing gstreamer/gtk development packages in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e111d61c54832bb9544472c0cddc6a