### PR TITLE
Add multi-port listening support with GUI controls

### DIFF
--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -172,6 +172,7 @@ void uv_viewer_set_event_callback(UvViewer *viewer, UvViewerEventCallback cb, gp
 bool uv_viewer_select_source(UvViewer *viewer, int index, GError **error);
 bool uv_viewer_select_next_source(UvViewer *viewer, GError **error);
 int  uv_viewer_get_selected_source(const UvViewer *viewer);
+bool uv_viewer_add_listen_port(UvViewer *viewer, int port, GError **error);
 
 bool uv_viewer_update_pipeline(UvViewer *viewer, const UvPipelineOverrides *overrides, GError **error);
 

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -51,6 +51,8 @@ typedef struct {
 
 typedef struct {
     int listen_port;
+    GArray *listen_ports;
+    gboolean listeners_dirty;
     GThread *thread;
     volatile sig_atomic_t running;
     volatile sig_atomic_t push_enabled;
@@ -198,6 +200,7 @@ void     relay_controller_stop(RelayController *rc);
 gboolean relay_controller_select(RelayController *rc, int index, GError **error);
 gboolean relay_controller_select_next(RelayController *rc, GError **error);
 int      relay_controller_selected(const RelayController *rc);
+gboolean relay_controller_add_listen_port(RelayController *rc, int port, gboolean validate_bind, GError **error);
 void     relay_controller_snapshot(RelayController *rc, UvViewerStats *stats, int clock_rate);
 void     relay_controller_set_appsrc(RelayController *rc, GstAppSrc *appsrc);
 void     relay_controller_set_push_enabled(RelayController *rc, gboolean enabled);

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -131,6 +131,11 @@ int uv_viewer_get_selected_source(const UvViewer *viewer) {
     return relay_controller_selected(&viewer->relay);
 }
 
+bool uv_viewer_add_listen_port(UvViewer *viewer, int port, GError **error) {
+    if (!viewer) return FALSE;
+    return relay_controller_add_listen_port(&viewer->relay, port, TRUE, error);
+}
+
 bool uv_viewer_update_pipeline(UvViewer *viewer, const UvPipelineOverrides *overrides, GError **error) {
     if (!viewer) return FALSE;
     return pipeline_controller_update(&viewer->pipeline, overrides, error);


### PR DESCRIPTION
## Summary
- enable the relay controller to maintain multiple UDP listening sockets and expose an API for adding ports at runtime
- allow the GUI to add session-scoped extra listen ports, update the status display, and restore them after viewer restarts
- debounce source selection changes in the GUI to avoid rapid pipeline switches

## Testing
- make *(fails: missing GTK/GStreamer development packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13eedfbd0832ba5f7b63c787f2b74