### PR TITLE
Capture frame block timeline samples

### DIFF
--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -162,6 +162,7 @@ static void stats_range_changed(GObject *dropdown, GParamSpec *pspec, gpointer u
 static void stats_chart_draw(GtkDrawingArea *area, cairo_t *cr, int width, int height, gpointer user_data);
 static void frame_block_draw(GtkDrawingArea *area, cairo_t *cr, int width, int height, gpointer user_data);
 static void frame_overlay_draw(GtkDrawingArea *area, cairo_t *cr, int width, int height, gpointer user_data);
+static void stats_history_push(GuiContext *ctx, const StatsSample *sample);
 static gboolean stats_history_push_frame_block_updates(GuiContext *ctx,
                                                        const UvFrameBlockStats *fb,
                                                        guint prev_next_index,


### PR DESCRIPTION
## Summary
- track the GUI's last stats refresh so timeline spacing can be derived
- push every new frame block sample into the stats history with interpolated timestamps
- refresh stats using the new helper so overlay charts render each frame seen since the prior update

## Testing
- make *(fails: missing gstreamer/gtk development packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e41303bafc832b9d56f81dea7fcbe5