### PR TITLE
Stabilize decoder FPS and add per-source input FPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts
+*.o
+*.d
+
+# Built binary
+/udp-h265-viewer
+
+# Editor / OS noise
+*.swp
+*~
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+make                         # build ./udp-h265-viewer
+make clean && make           # full rebuild after header/flag changes
+sudo make install            # install to $PREFIX/bin (default /usr/local) plus desktop entry
+./udp-h265-viewer [OPTIONS]  # see README.md for the full CLI option table
+```
+
+There is no automated test harness. Validate changes by pointing the viewer at a `gst-launch-1.0` test stream (recipe in `README.md`) and watching the GUI Monitor tab. Capture decoder FPS / jitter before and after when changes touch QoS-sensitive paths.
+
+`src/cli_shell.c` exists but is **not** wired into the Makefile — `gui_shell.c` is the only shell built today. If you need text-mode telemetry, add `cli_shell.c` to `SRCS` in `Makefile` and call `uv_cli_run` from `main.c`.
+
+## Architecture
+
+The viewer is built around a single `UvViewer` (defined in `src/uv_internal.h`) that owns three long-lived subsystems plus shared stats containers. Public API lives in `include/uv_viewer.h`; everything else is private and lives behind `src/uv_internal.h`.
+
+```
+main.c → uv_viewer_new() → relay_controller + pipeline_controller + decoder/qos stats
+                            ↓                       ↓
+                    own UDP recv thread      own GstBus GMainLoop thread
+                            ↓                       ↓
+                            └──── GstAppSrc ────────┘
+                            (relay pushes RTP buffers into pipeline)
+
+gui_shell.c (GTK 4 main thread) ── polls uv_viewer_get_stats() on a 200 ms timer
+```
+
+Key design points:
+
+- **The relay does its own UDP `recvfrom`** (not `udpsrc`). `relay_controller.c` runs a dedicated thread that demultiplexes by source address into `UvRelaySource` slots, tracks RTP sequence/jitter/marker stats, and forwards the *currently selected* source's packets into the pipeline via `GstAppSrc`. Switching sources is instantaneous and per-source counters keep accumulating in the background.
+- **The pipeline thread** (`pipeline_builder.c`) owns a `GMainLoop` on its own thread for bus messages and dynamic element rebuilds (`pipeline_controller_update`). The decoder pad has a buffer probe that calls `uv_internal_decoder_stats_push_frame` — that's where decoded-frame timestamps are recorded.
+- **Stats are collected from two places.** `relay_controller_snapshot` fills in per-source RTP stats; `pipeline_controller_snapshot` fills in queue/decoder/QoS/audio fields. The GUI/CLI assembles them via `uv_viewer_get_stats()`.
+
+### FPS computation (load-bearing detail)
+
+Both the per-source "input FPS" (RTP marker bits) and the "decoder FPS" (decoded-frame probe) use a sliding window of frame timestamps:
+
+- Each frame event appends `g_get_monotonic_time()` into a circular buffer of size `UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES` (relay) or `UV_DECODER_FPS_WINDOW_SAMPLES` (decoder), both 512.
+- At snapshot time the consumer walks the buffer and counts entries that fall within a 1 s window, then reports `(count - 1) / (last - first)`.
+- This replaces an older snapshot-delta approach that was sensitive to GTK timer jitter — do not regress to "frames since last snapshot" math, it produces phantom dips.
+
+The relay's marker-frame counting and frame-block byte accumulation **must** be gated on `unique_packet` (i.e. the RTP sequence wasn't already in the dedup window). Counting duplicates inflates both metrics.
+
+### Locking & threading rules
+
+- `RelayController.lock`, `PipelineController` element fields, `DecoderStats.lock`, and `QoSDatabase.lock` are independent — never hold more than one at a time.
+- The relay thread is the only writer of `UvRelaySource` fields; readers (snapshots) must hold `RelayController.lock`.
+- The decoder pad probe runs on a GStreamer streaming thread — it only touches `DecoderStats` under its own lock.
+- GTK calls happen only from the GUI main thread. Stats polling pulls a snapshot copy; do not retain pointers from `UvViewerStats` past the next call.
+
+### Public-API stability
+
+`include/uv_viewer.h` is the contract for any external consumer. When extending `UvSourceStats`, `UvViewerStats`, or `UvViewerConfig`, append fields rather than reordering — downstream binaries link against this layout.
+
+## Conventions (from AGENTS.md)
+
+- C11 with GCC, four-space indent, K&R braces, `snake_case` internals, ALL_CAPS only for macros.
+- Keep `-Wall -Wextra` clean.
+- Comment only non-obvious or cross-thread behavior.
+- Commit subjects: short imperative, ≤72 chars; mention QoS-impacting changes in the body. Rebuild before opening a PR and note manual test coverage.
+
+## Runtime notes
+
+- Relay binds `0.0.0.0` — firewall the host when ingesting real feeds.
+- Headless runs auto-fall back to `fakesink` so diagnostics still work; `--video-sink fakesink` forces it.
+- `GST_DEBUG=2 ./udp-h265-viewer` is the standard way to inspect pipeline negotiation / QoS messages.

--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -65,6 +65,8 @@ typedef struct {
     uint64_t rtp_lost_packets;
     uint64_t rtp_duplicate_packets;
     uint64_t rtp_reordered_packets;
+    uint64_t rtp_marker_frames;
+    double rtp_marker_fps;
     double rfc3550_jitter_ms;
     double seconds_since_last_seen;
 } UvSourceStats;

--- a/src/cli_shell.c
+++ b/src/cli_shell.c
@@ -101,7 +101,8 @@ static void print_stats(UvViewer *viewer, int clock_rate) {
                     " rate=%s last_seen=%.1fs"
                     " | rtp_unique=%" G_GUINT64_FORMAT " expected=%" G_GUINT64_FORMAT
                     " lost=%" G_GUINT64_FORMAT " dup=%" G_GUINT64_FORMAT
-                    " reorder=%" G_GUINT64_FORMAT " jitter=%.2fms\n",
+                    " reorder=%" G_GUINT64_FORMAT " marker_frames=%" G_GUINT64_FORMAT
+                    " input_fps=%.2f jitter=%.2fms\n",
                     i,
                     s->selected ? "*" : "",
                     s->address,
@@ -116,6 +117,8 @@ static void print_stats(UvViewer *viewer, int clock_rate) {
                     s->rtp_lost_packets,
                     s->rtp_duplicate_packets,
                     s->rtp_reordered_packets,
+                    s->rtp_marker_frames,
+                    s->rtp_marker_fps,
                     jitter_ms);
         }
     }

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -23,7 +23,8 @@ typedef enum {
     STATS_METRIC_DUP,
     STATS_METRIC_REORDER,
     STATS_METRIC_JITTER,
-    STATS_METRIC_FPS,
+    STATS_METRIC_INPUT_FPS,
+    STATS_METRIC_DECODER_FPS,
     STATS_METRIC_COUNT
 } StatsMetric;
 
@@ -142,7 +143,8 @@ typedef struct {
     double dup_packets;
     double reorder_packets;
     double jitter_ms;
-    double fps_current;
+    double input_fps;
+    double decoder_fps_current;
     double frame_lateness_ms;
     double frame_size_kb;
     gboolean frame_valid;
@@ -1495,7 +1497,8 @@ static double stats_metric_value(const StatsSample *sample, StatsMetric metric) 
         case STATS_METRIC_DUP:     return sample->dup_packets;
         case STATS_METRIC_REORDER: return sample->reorder_packets;
         case STATS_METRIC_JITTER:  return sample->jitter_ms;
-        case STATS_METRIC_FPS:     return sample->fps_current;
+        case STATS_METRIC_INPUT_FPS: return sample->input_fps;
+        case STATS_METRIC_DECODER_FPS: return sample->decoder_fps_current;
         default:                   return 0.0;
     }
 }
@@ -1685,11 +1688,11 @@ static void refresh_stats(GuiContext *ctx) {
             if (detail_source) {
                 char rate_buf[64];
                 format_bitrate(detail_source->inbound_bitrate_bps, rate_buf, sizeof(rate_buf));
-                char detail[256];
+                char detail[320];
                 g_snprintf(detail, sizeof(detail),
                            "%u: %s\nrx=%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT
                            " fwd=%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT
-                           " rate=%s jitter=%.2fms last_seen=%.1fs",
+                           " rate=%s input_fps=%.2f jitter=%.2fms last_seen=%.1fs",
                            detail_index,
                            detail_source->address,
                            detail_source->rx_packets,
@@ -1697,6 +1700,7 @@ static void refresh_stats(GuiContext *ctx) {
                            detail_source->forwarded_packets,
                            detail_source->forwarded_bytes,
                            rate_buf,
+                           detail_source->rtp_marker_fps,
                            detail_source->rfc3550_jitter_ms,
                            detail_source->seconds_since_last_seen >= 0.0 ? detail_source->seconds_since_last_seen : 0.0);
                 if (waiting_for_switch) {
@@ -1744,7 +1748,8 @@ static void refresh_stats(GuiContext *ctx) {
         sample.dup_packets = (double)viewer_selected_source->rtp_duplicate_packets;
         sample.reorder_packets = (double)viewer_selected_source->rtp_reordered_packets;
         sample.jitter_ms = viewer_selected_source->rfc3550_jitter_ms;
-        sample.fps_current = stats.decoder.instantaneous_fps;
+        sample.input_fps = viewer_selected_source->rtp_marker_fps;
+        sample.decoder_fps_current = stats.decoder.instantaneous_fps;
         double latest_lateness = NAN;
         double latest_size = NAN;
         gboolean latest_missing = FALSE;
@@ -2763,6 +2768,7 @@ static GtkWidget *build_stats_page(GuiContext *ctx) {
         "RTP Duplicate Packets",
         "RTP Reordered Packets",
         "RTP Jitter (ms)",
+        "Input Frame FPS",
         "Decoder FPS (current)"
     };
 

--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -980,19 +980,20 @@ void pipeline_controller_snapshot(PipelineController *pc, UvViewerStats *stats) 
     stats->audio_active = audio_active;
     guint64 frames_total;
     gint64 first_us;
-    gint64 prev_snapshot_us;
-    guint64 prev_frames;
     gint64 last_frame_us;
     double last_snapshot_fps;
     double inst_fps = 0.0;
     double avg_fps = 0.0;
     gboolean recent_frame = FALSE;
+    gint64 window_start_us = now_us - 1000000;
+    gint64 first_window_us = 0;
+    gint64 last_window_us = 0;
+    guint window_frames = 0;
+    guint oldest_frame_idx;
 
     g_mutex_lock(&pc->viewer->decoder.lock);
     frames_total = pc->viewer->decoder.frames_total;
     first_us = pc->viewer->decoder.first_frame_us;
-    prev_snapshot_us = pc->viewer->decoder.prev_snapshot_us;
-    prev_frames = pc->viewer->decoder.prev_frames;
     last_frame_us = pc->viewer->decoder.prev_timestamp_us;
     last_snapshot_fps = pc->viewer->decoder.last_snapshot_fps;
 
@@ -1001,30 +1002,35 @@ void pipeline_controller_snapshot(PipelineController *pc, UvViewerStats *stats) 
         if (dt > 0.0) avg_fps = (double)frames_total / dt;
     }
 
-    gboolean have_new_frames = frames_total > prev_frames;
-    if (have_new_frames && prev_snapshot_us != 0 && now_us > prev_snapshot_us) {
-        double dt = (now_us - prev_snapshot_us) / 1e6;
-        if (dt > 0.0) inst_fps = (double)(frames_total - prev_frames) / dt;
+    /* Compute current FPS from decoded-frame timestamps, not the GUI stats
+     * timer interval.  The old snapshot-delta math could report a false
+     * dip when a 200 ms GTK timer callback arrived late. */
+    oldest_frame_idx = (pc->viewer->decoder.frame_times_head +
+                        UV_DECODER_FPS_WINDOW_SAMPLES -
+                        pc->viewer->decoder.frame_times_count) %
+                       UV_DECODER_FPS_WINDOW_SAMPLES;
+    for (guint i = 0; i < pc->viewer->decoder.frame_times_count; i++) {
+        guint idx = (oldest_frame_idx + i) % UV_DECODER_FPS_WINDOW_SAMPLES;
+        gint64 frame_us = pc->viewer->decoder.frame_times_us[idx];
+        if (frame_us < window_start_us || frame_us > now_us) continue;
+        if (first_window_us == 0) first_window_us = frame_us;
+        last_window_us = frame_us;
+        window_frames++;
     }
 
     if (last_frame_us > 0 && now_us > last_frame_us) {
         recent_frame = (now_us - last_frame_us) < 500000; // 0.5s
     }
 
-    if (!have_new_frames) {
-        if (recent_frame && last_snapshot_fps > 0.0) {
-            inst_fps = last_snapshot_fps;
-        } else if (avg_fps > 0.0) {
-            inst_fps = avg_fps;
-        } else {
-            inst_fps = 0.0;
-        }
-    } else if (inst_fps <= 0.0 && avg_fps > 0.0) {
+    if (recent_frame && window_frames >= 2 && last_window_us > first_window_us) {
+        inst_fps = (double)(window_frames - 1u) * 1000000.0 /
+                   (double)(last_window_us - first_window_us);
+    } else if (recent_frame && last_snapshot_fps > 0.0) {
+        inst_fps = last_snapshot_fps;
+    } else if (avg_fps > 0.0) {
         inst_fps = avg_fps;
     }
 
-    pc->viewer->decoder.prev_frames = frames_total;
-    pc->viewer->decoder.prev_snapshot_us = now_us;
     pc->viewer->decoder.last_snapshot_fps = inst_fps;
     g_mutex_unlock(&pc->viewer->decoder.lock);
 

--- a/src/relay_controller.c
+++ b/src/relay_controller.c
@@ -248,6 +248,10 @@ static void relay_source_clear_stats(UvRelaySource *src, gboolean reset_totals) 
     src->rtp_unique_packets = 0;
     src->rtp_duplicate_packets = 0;
     src->rtp_reordered_packets = 0;
+    src->rtp_marker_frames = 0;
+    src->frame_times_head = 0;
+    src->frame_times_count = 0;
+    memset(src->frame_times_us, 0, sizeof(src->frame_times_us));
     for (guint i = 0; i < UV_RTP_WIN_SIZE; ++i) {
         src->rtp_seq_slot[i] = UV_RTP_SLOT_EMPTY;
     }
@@ -305,6 +309,39 @@ static inline uint32_t rtp_now_ts_from_us(int clock_rate, gint64 us) {
 
 static inline uint32_t rtp_now_ts(int clock_rate) {
     return rtp_now_ts_from_us(clock_rate, g_get_monotonic_time());
+}
+
+static void source_record_marker_frame(UvRelaySource *src, gint64 arrival_us) {
+    if (!src || arrival_us <= 0) return;
+
+    src->rtp_marker_frames++;
+    src->frame_times_us[src->frame_times_head] = arrival_us;
+    src->frame_times_head = (src->frame_times_head + 1u) % UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES;
+    if (src->frame_times_count < UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES) {
+        src->frame_times_count++;
+    }
+}
+
+static double source_marker_window_fps(const UvRelaySource *src, gint64 now_us) {
+    if (!src || src->frame_times_count < 2 || now_us <= 0) return 0.0;
+
+    const gint64 window_start_us = now_us - G_USEC_PER_SEC;
+    const guint capacity = UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES;
+    const guint oldest = (src->frame_times_head + capacity - src->frame_times_count) % capacity;
+    guint count = 0;
+    gint64 first_us = 0;
+    gint64 last_us = 0;
+
+    for (guint i = 0; i < src->frame_times_count; i++) {
+        gint64 ts = src->frame_times_us[(oldest + i) % capacity];
+        if (ts < window_start_us || ts > now_us) continue;
+        if (count == 0) first_us = ts;
+        last_us = ts;
+        count++;
+    }
+
+    if (count < 2 || last_us <= first_us) return 0.0;
+    return ((double)(count - 1u) * (double)G_USEC_PER_SEC) / (double)(last_us - first_us);
 }
 
 static void frame_block_process_packet(RelayController *rc,
@@ -450,10 +487,6 @@ static inline void rtp_update_stats(RelayController *rc,
 
     gboolean marker = (p[1] & 0x80) != 0;
 
-    if (rc->frame_block.enabled && is_selected) {
-        s->frame_block_accum_bytes += (uint64_t)len;
-    }
-
     uint16_t seq = (uint16_t)((p[2] << 8) | p[3]);
     uint32_t ts  = (uint32_t)((p[4] << 24) | (p[5] << 16) | (p[6] << 8) | p[7]);
 
@@ -465,13 +498,19 @@ static inline void rtp_update_stats(RelayController *rc,
     }
 
     guint idx = ext % UV_RTP_WIN_SIZE;
+    gboolean unique_packet = FALSE;
     if (s->rtp_seq_slot[idx] == ext) {
         s->rtp_duplicate_packets++;
     } else {
         if (ext < s->rtp_max_ext_seq) s->rtp_reordered_packets++;
         s->rtp_seq_slot[idx] = ext;
         s->rtp_unique_packets++;
+        unique_packet = TRUE;
         if (ext > s->rtp_max_ext_seq) s->rtp_max_ext_seq = ext;
+    }
+
+    if (unique_packet && rc->frame_block.enabled && is_selected) {
+        s->frame_block_accum_bytes += (uint64_t)len;
     }
 
     gint64 arrival_us = g_get_monotonic_time();
@@ -487,8 +526,9 @@ static inline void rtp_update_stats(RelayController *rc,
         s->jitter_prev_transit = transit;
     }
 
-    if (marker) {
+    if (marker && unique_packet) {
         uint64_t frame_size_bytes = s->frame_block_accum_bytes;
+        source_record_marker_frame(s, arrival_us);
         frame_block_process_packet(rc, s, ts, marker, arrival_us, clock_rate, is_selected, frame_size_bytes);
         s->frame_block_accum_bytes = 0;
     }
@@ -803,6 +843,8 @@ void relay_controller_snapshot(RelayController *rc, UvViewerStats *stats, int cl
         }
         s.rtp_duplicate_packets = src->rtp_duplicate_packets;
         s.rtp_reordered_packets = src->rtp_reordered_packets;
+        s.rtp_marker_frames = src->rtp_marker_frames;
+        s.rtp_marker_fps = source_marker_window_fps(src, now_us);
         if (src->jitter_value > 0.0) {
             s.rfc3550_jitter_ms = (src->jitter_value * 1000.0) / (double)MAX(clock_rate, 1);
         }

--- a/src/stats.c
+++ b/src/stats.c
@@ -20,10 +20,11 @@ void uv_internal_decoder_stats_reset(DecoderStats *stats) {
     g_mutex_lock(&stats->lock);
     stats->frames_total = 0;
     stats->first_frame_us = 0;
-    stats->prev_frames = 0;
     stats->prev_timestamp_us = 0;
-    stats->prev_snapshot_us = 0;
     stats->last_snapshot_fps = 0.0;
+    memset(stats->frame_times_us, 0, sizeof(stats->frame_times_us));
+    stats->frame_times_head = 0;
+    stats->frame_times_count = 0;
     g_mutex_unlock(&stats->lock);
 }
 
@@ -33,6 +34,11 @@ void uv_internal_decoder_stats_push_frame(DecoderStats *stats, gint64 now_us) {
     stats->frames_total++;
     if (stats->first_frame_us == 0) stats->first_frame_us = now_us;
     stats->prev_timestamp_us = now_us;
+    stats->frame_times_us[stats->frame_times_head] = now_us;
+    stats->frame_times_head = (stats->frame_times_head + 1u) % UV_DECODER_FPS_WINDOW_SAMPLES;
+    if (stats->frame_times_count < UV_DECODER_FPS_WINDOW_SAMPLES) {
+        stats->frame_times_count++;
+    }
     g_mutex_unlock(&stats->lock);
 }
 
@@ -144,6 +150,7 @@ static void populate_source_snapshot(const UvRelaySource *src, int clock_rate, U
     }
     out->rtp_duplicate_packets = src->rtp_duplicate_packets;
     out->rtp_reordered_packets = src->rtp_reordered_packets;
+    out->rtp_marker_frames = src->rtp_marker_frames;
     if (src->jitter_value > 0.0) {
         out->rfc3550_jitter_ms = (src->jitter_value * 1000.0) / (double)MAX(clock_rate, 1);
     }

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -14,6 +14,8 @@ G_BEGIN_DECLS
 #define UV_RELAY_BUF_SIZE 65536
 #define UV_RTP_WIN_SIZE 4096
 #define UV_RTP_SLOT_EMPTY 0xffffffffu
+#define UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES 512u
+#define UV_DECODER_FPS_WINDOW_SAMPLES 512u
 
 struct UvFrameBlockState;
 
@@ -40,9 +42,13 @@ typedef struct {
     uint64_t rtp_duplicate_packets;
     uint64_t rtp_reordered_packets;
     uint32_t rtp_seq_slot[UV_RTP_WIN_SIZE];
+    uint64_t rtp_marker_frames;
+    gint64   frame_times_us[UV_SOURCE_FRAME_FPS_WINDOW_SAMPLES];
+    guint    frame_times_head;
+    guint    frame_times_count;
 
     bool     jitter_initialized;
-   uint32_t jitter_prev_transit;
+    uint32_t jitter_prev_transit;
     double   jitter_value;
 
     struct UvFrameBlockState *frame_block;
@@ -81,10 +87,11 @@ typedef struct {
 typedef struct {
     guint64 frames_total;
     gint64 first_frame_us;
-    guint64 prev_frames;
     gint64 prev_timestamp_us;
-    gint64 prev_snapshot_us;
     double last_snapshot_fps;
+    gint64 frame_times_us[UV_DECODER_FPS_WINDOW_SAMPLES];
+    guint frame_times_head;
+    guint frame_times_count;
     GMutex lock;
 } DecoderStats;
 


### PR DESCRIPTION
## Summary
- Decoder FPS now uses a 1 s sliding window over recorded frame timestamps (decoder pad probe), replacing the snapshot-delta math that dipped when the GTK 200 ms timer ran late.
- New per-source **input FPS** derived from RTP marker bits, exposed in the CLI dump and split out as its own GUI stats metric (old "FPS" entry becomes Input Frame FPS + Decoder FPS).
- Bug fix: marker-frame counting and frame-block byte accumulation are now gated on the unique-packet check, so duplicate RTP packets no longer inflate either metric.
- Added `CLAUDE.md` (architecture/threading rules) and `.gitignore` for build artifacts.

## Test plan
- [x] `make clean && make` — clean build, no warnings
- [ ] Live source: confirm decoder FPS no longer dips at GUI refresh boundaries
- [ ] Live source: confirm Input Frame FPS tracks sender frame rate within ~1 fps
- [ ] Inject duplicate RTP packets: confirm `marker_frames` and frame-block byte totals do not double-count

🤖 Generated with [Claude Code](https://claude.com/claude-code)