### PR TITLE
Recover from mid-stream resolution changes

### DIFF
--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -168,6 +168,7 @@ void uv_viewer_free(UvViewer *viewer);
 
 bool uv_viewer_start(UvViewer *viewer, GError **error);
 void uv_viewer_stop(UvViewer *viewer);
+bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error);
 
 void uv_viewer_set_event_callback(UvViewer *viewer, UvViewerEventCallback cb, gpointer user_data);
 

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -1910,6 +1910,21 @@ static void update_sources_toggle_label(GuiContext *ctx, gboolean hidden) {
 static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
     (void)button;
     GuiContext *ctx = user_data;
+    if (!ctx || !ctx->viewer) return;
+
+    /* Drop the GTK paintable binding before tearing the sink down so we
+     * don't keep a dangling ref or signal handler on the old element. */
+    detach_bound_sink(ctx);
+
+    GError *error = NULL;
+    if (!uv_viewer_restart_pipeline(ctx->viewer, &error)) {
+        uv_log_error("Pipeline restart failed: %s",
+                     error && error->message ? error->message : "unknown");
+        if (error) g_error_free(error);
+    }
+
+    /* Re-bind the paintable to the freshly built sink and update stats. */
+    ensure_video_paintable(ctx);
     refresh_stats(ctx);
 }
 
@@ -2564,7 +2579,10 @@ static GtkWidget *build_monitor_page(GuiContext *ctx) {
     GtkWidget *button_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
     gtk_box_append(GTK_BOX(page), button_box);
 
-    GtkWidget *refresh_button = gtk_button_new_with_label("Refresh");
+    GtkWidget *refresh_button = gtk_button_new_with_label("Restart Pipeline");
+    gtk_widget_set_tooltip_text(refresh_button,
+                                "Tear down and rebuild the GStreamer pipeline. "
+                                "Useful when a mid-stream resolution / SPS change leaves the picture frozen.");
     g_signal_connect(refresh_button, "clicked", G_CALLBACK(on_refresh_button_clicked), ctx);
     gtk_box_append(GTK_BOX(button_box), refresh_button);
 

--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -161,12 +161,73 @@ static gboolean bus_cb(GstBus *bus, GstMessage *msg, gpointer user_data) {
     return TRUE;
 }
 
+static gboolean sink_bounce_idle(gpointer user_data) {
+    PipelineController *pc = (PipelineController *)user_data;
+    if (!pc) return G_SOURCE_REMOVE;
+
+    GstElement *sink = pc->sink;
+    if (sink) {
+        uv_log_info("Bouncing video sink (READY -> PLAYING) to recover after caps change");
+        gst_element_set_state(sink, GST_STATE_READY);
+        gst_element_sync_state_with_parent(sink);
+    }
+    g_atomic_int_set(&pc->sink_bounce_pending, 0);
+    return G_SOURCE_REMOVE;
+}
+
+static void schedule_sink_bounce(PipelineController *pc) {
+    if (!pc || !pc->loop_context) return;
+    if (!g_atomic_int_compare_and_exchange(&pc->sink_bounce_pending, 0, 1)) return;
+    GSource *src = g_idle_source_new();
+    g_source_set_priority(src, G_PRIORITY_DEFAULT);
+    g_source_set_callback(src, sink_bounce_idle, pc, NULL);
+    g_source_attach(src, pc->loop_context);
+    g_source_unref(src);
+}
+
+static void handle_decoder_caps_event(PipelineController *pc, GstEvent *event) {
+    GstCaps *caps = NULL;
+    gst_event_parse_caps(event, &caps);
+    if (!caps || gst_caps_is_empty(caps) || !gst_caps_is_fixed(caps)) return;
+
+    const GstStructure *s = gst_caps_get_structure(caps, 0);
+    if (!s) return;
+
+    gint width = 0, height = 0;
+    gst_structure_get_int(s, "width", &width);
+    gst_structure_get_int(s, "height", &height);
+    if (width <= 0 || height <= 0) return;
+
+    gint old_w = pc->last_video_width;
+    gint old_h = pc->last_video_height;
+    pc->last_video_width = width;
+    pc->last_video_height = height;
+
+    if (old_w == 0 || old_h == 0) {
+        return; /* first negotiation, nothing to recover from */
+    }
+    if (old_w == width && old_h == height) {
+        return;
+    }
+
+    uv_log_info("Decoder output caps changed: %dx%d -> %dx%d (scheduling sink bounce)",
+                old_w, old_h, width, height);
+    schedule_sink_bounce(pc);
+}
+
 static GstPadProbeReturn dec_src_probe(GstPad *pad, GstPadProbeInfo *info, gpointer user_data) {
     (void)pad;
     PipelineController *pc = (PipelineController *)user_data;
-    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
+    GstPadProbeType ptype = GST_PAD_PROBE_INFO_TYPE(info);
+
+    if (ptype & GST_PAD_PROBE_TYPE_BUFFER) {
         gint64 now_us = g_get_monotonic_time();
         uv_internal_decoder_stats_push_frame(&pc->viewer->decoder, now_us);
+    } else if (ptype & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
+        GstEvent *event = GST_PAD_PROBE_INFO_EVENT(info);
+        if (event && GST_EVENT_TYPE(event) == GST_EVENT_CAPS) {
+            handle_decoder_caps_event(pc, event);
+        }
     }
     return GST_PAD_PROBE_OK;
 }
@@ -692,7 +753,9 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
 
     GstPad *dec_src = gst_element_get_static_pad(pc->decoder, "src");
     if (dec_src) {
-        pc->decoder_probe_id = gst_pad_add_probe(dec_src, GST_PAD_PROBE_TYPE_BUFFER,
+        pc->decoder_probe_id = gst_pad_add_probe(dec_src,
+                                                 GST_PAD_PROBE_TYPE_BUFFER |
+                                                 GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM,
                                                  dec_src_probe, pc, NULL);
         gst_object_unref(dec_src);
     }

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -162,6 +162,9 @@ typedef struct {
     GMainContext *loop_context;
     guint bus_watch_id;
     gulong decoder_probe_id;
+    gint last_video_width;
+    gint last_video_height;
+    gint sink_bounce_pending;
     gboolean sink_is_fakesink;
     GPtrArray *sink_factories;
     guint sink_factory_index;

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -110,6 +110,50 @@ void uv_viewer_stop(UvViewer *viewer) {
     pipeline_controller_stop(&viewer->pipeline);
 }
 
+bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
+    if (!viewer) return FALSE;
+
+    g_mutex_lock(&viewer->state_lock);
+    gboolean was_started = viewer->started;
+    g_mutex_unlock(&viewer->state_lock);
+
+    if (!was_started) {
+        return uv_viewer_start(viewer, error);
+    }
+
+    /* Stop pushing into the dying appsrc and drop our reference. */
+    relay_controller_set_push_enabled(&viewer->relay, FALSE);
+    relay_controller_set_appsrc(&viewer->relay, NULL);
+
+    /* Tear the pipeline all the way down so build_pipeline runs again. */
+    pipeline_controller_deinit(&viewer->pipeline);
+
+    /* Reset decoder + QoS stats so they reflect the new element instances,
+     * not the ones we just freed (paths often match by name and would alias). */
+    uv_internal_decoder_stats_reset(&viewer->decoder);
+    uv_internal_qos_db_clear(&viewer->qos);
+
+    if (!pipeline_controller_init(&viewer->pipeline, viewer, error)) {
+        g_mutex_lock(&viewer->state_lock);
+        viewer->started = FALSE;
+        g_mutex_unlock(&viewer->state_lock);
+        return FALSE;
+    }
+
+    if (!pipeline_controller_start(&viewer->pipeline, error)) {
+        g_mutex_lock(&viewer->state_lock);
+        viewer->started = FALSE;
+        g_mutex_unlock(&viewer->state_lock);
+        return FALSE;
+    }
+
+    relay_controller_set_appsrc(&viewer->relay, pipeline_controller_get_appsrc(&viewer->pipeline));
+    /* The new appsrc's need-data callback will re-enable push when ready. */
+
+    uv_log_info("Pipeline restarted");
+    return TRUE;
+}
+
 void uv_viewer_set_event_callback(UvViewer *viewer, UvViewerEventCallback cb, gpointer user_data) {
     if (!viewer) return;
     viewer->event_cb = cb;

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -121,8 +121,11 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
         return uv_viewer_start(viewer, error);
     }
 
-    /* Stop pushing into the dying appsrc and drop our reference. */
-    relay_controller_set_push_enabled(&viewer->relay, FALSE);
+    /* Stop the relay thread first — relay_push_buffer reads rc->appsrc
+     * outside the lock, so an in-flight push could otherwise dereference
+     * the appsrc element we are about to free. Joining the recv thread
+     * guarantees no concurrent access for the rest of the rebuild. */
+    relay_controller_stop(&viewer->relay);
     relay_controller_set_appsrc(&viewer->relay, NULL);
 
     /* Tear the pipeline all the way down so build_pipeline runs again. */
@@ -134,6 +137,9 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
     uv_internal_qos_db_clear(&viewer->qos);
 
     if (!pipeline_controller_init(&viewer->pipeline, viewer, error)) {
+        /* Try to keep the relay alive so source discovery can continue
+         * even when the pipeline failed to come back. */
+        relay_controller_start(&viewer->relay);
         g_mutex_lock(&viewer->state_lock);
         viewer->started = FALSE;
         g_mutex_unlock(&viewer->state_lock);
@@ -141,6 +147,7 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
     }
 
     if (!pipeline_controller_start(&viewer->pipeline, error)) {
+        relay_controller_start(&viewer->relay);
         g_mutex_lock(&viewer->state_lock);
         viewer->started = FALSE;
         g_mutex_unlock(&viewer->state_lock);
@@ -148,6 +155,14 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
     }
 
     relay_controller_set_appsrc(&viewer->relay, pipeline_controller_get_appsrc(&viewer->pipeline));
+    if (!relay_controller_start(&viewer->relay)) {
+        g_set_error(error, g_quark_from_static_string("uv-viewer"), 100,
+                    "Failed to restart relay thread");
+        g_mutex_lock(&viewer->state_lock);
+        viewer->started = FALSE;
+        g_mutex_unlock(&viewer->state_lock);
+        return FALSE;
+    }
     /* The new appsrc's need-data callback will re-enable push when ready. */
 
     uv_log_info("Pipeline restarted");


### PR DESCRIPTION
## Summary
- Repurpose the Monitor tab's Refresh button as **Restart Pipeline**: detaches the paintable, calls a new `uv_viewer_restart_pipeline` (full deinit/init/start cycle), and re-binds the paintable.
- Add automatic caps-change detection on the decoder src pad. When width/height changes mid-stream, schedule a sink bounce (READY → sync state with parent) on the pipeline's `loop_context`, debounced via atomic CAS.
- Fix segfault on Restart Pipeline: stop the relay thread before tearing down the pipeline, then restart it after the new appsrc is bound. Closes a TOCTOU race where `relay_push_buffer` read `rc->appsrc` outside the lock and could dereference an element that the GTK thread had just freed.
- Clear the QoS database during restart so element-path matches don't alias stats from freed elements onto fresh ones.

## Test plan
- [ ] Start `gst-launch-1.0` test stream, click **Restart Pipeline** repeatedly under load — no segfault.
- [ ] Trigger a mid-stream resolution change; verify picture recovers without manual restart.
- [ ] Verify decoder FPS / QoS stats reset cleanly across restart (no stale entries).
- [ ] Headless run with `--video-sink fakesink` still survives a Restart Pipeline click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)