### PR TITLE
Implement shared-memory ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS ?= -std=c11 -Wall -Wextra -O2 -g
+CFLAGS ?= -std=c11 -Wall -Wextra -O2 -g -pthread
 PKG_CONFIG ?= pkg-config
 GST_FLAGS := $(shell $(PKG_CONFIG) --cflags gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 gobject-2.0 glib-2.0 gio-2.0)
 GST_LIBS := $(shell $(PKG_CONFIG) --libs gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 gobject-2.0 glib-2.0 gio-2.0)
@@ -23,6 +23,7 @@ SRCS := \
 	src/stats.c \
 	src/logging.c \
 	src/sidecar.c \
+	src/shm_ingress.c \
 	src/gui_shell.c
 
 OBJS := $(SRCS:.c=.o)
@@ -32,7 +33,7 @@ TARGET := udp-h265-viewer
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ $(GST_LIBS) $(GTK_LIBS) -lm
+	$(CC) $(CFLAGS) -o $@ $^ $(GST_LIBS) $(GTK_LIBS) -lm -lrt -pthread
 
 # -MMD -MP emits a per-object .d listing its header prerequisites, so editing a
 # shared header (e.g. uv_viewer.h / uv_internal.h) rebuilds every dependent

--- a/include/frame_shm_format.h
+++ b/include/frame_shm_format.h
@@ -1,0 +1,41 @@
+#ifndef FRAME_SHM_FORMAT_H
+#define FRAME_SHM_FORMAT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define VFRM_MAGIC 0x5646524Du
+#define VFRM_VERSION 1u
+#define VFRM_HEADER_SIZE 192u
+#define VFRM_DEFAULT_SLOT_COUNT 16u
+#define VFRM_DEFAULT_SLOT_DATA_SIZE (512u * 1024u)
+
+#define VFRM_OFF_MAGIC 0u
+#define VFRM_OFF_VERSION 4u
+#define VFRM_OFF_SLOT_COUNT 8u
+#define VFRM_OFF_SLOT_DATA_SIZE 12u
+#define VFRM_OFF_TOTAL_SIZE 16u
+#define VFRM_OFF_EPOCH 20u
+#define VFRM_OFF_INIT_COMPLETE 24u
+#define VFRM_OFF_WRITE_IDX 64u
+#define VFRM_OFF_FUTEX_SEQ 72u
+#define VFRM_OFF_READ_IDX 128u
+#define VFRM_OFF_CONSUMER_WAITING 136u
+
+#define UV_FRAME_CODEC_H265 0x01u
+#define UV_FRAME_FLAG_IDR 0x01u
+
+typedef struct {
+    uint32_t pts;
+    uint8_t codec;
+    uint8_t flags;
+    uint16_t reserved;
+} VencFrameMeta;
+
+_Static_assert(sizeof(VencFrameMeta) == 8, "VencFrameMeta must be 8 bytes");
+
+static inline size_t vfrm_align8(size_t value) {
+    return (value + 7u) & ~(size_t)7u;
+}
+
+#endif

--- a/include/uv_viewer.h
+++ b/include/uv_viewer.h
@@ -9,6 +9,12 @@
 G_BEGIN_DECLS
 
 #define UV_VIEWER_ADDR_MAX 64
+#define UV_SHM_NAME_MAX 64
+
+typedef enum {
+    UV_SOURCE_UDP = 0,
+    UV_SOURCE_SHM
+} UvSourceKind;
 
 typedef struct _UvViewer UvViewer;
 
@@ -62,9 +68,12 @@ typedef struct {
     gboolean restream_enabled;                  // TRUE to forward the selected source
     char     restream_address[UV_VIEWER_ADDR_MAX]; // destination IPv4 address
     guint16  restream_port;                     // destination UDP port
+    gboolean shm_enabled;
+    char shm_name[UV_SHM_NAME_MAX];
 } UvViewerConfig;
 
 typedef struct {
+    UvSourceKind kind;
     char address[UV_VIEWER_ADDR_MAX];
     bool selected;
     uint64_t rx_packets;
@@ -99,6 +108,12 @@ typedef struct {
     uint64_t rtp_fu_packets;        /* RFC 7798 fragmentation packets (type 49) */
     double seconds_since_keyframe;  /* time since last IDR/CRA; -1 if none seen */
     double last_keyframe_interval_seconds; /* gap between two most recent keyframes; -1 if unknown */
+    gboolean shm_attached;
+    double shm_fill_pct;
+    uint64_t shm_full_drops;
+    uint64_t shm_oversize_drops;
+    uint64_t shm_bad_slots;
+    uint64_t shm_reattaches;
 } UvSourceStats;
 
 typedef struct {

--- a/specs/2026-07-12-shm-ingress/plan.md
+++ b/specs/2026-07-12-shm-ingress/plan.md
@@ -1,0 +1,242 @@
+# SHM ingress — implementation plan
+
+Companion to `requirements.md`. Anchors are against `772385c` (post-#24 restream).
+
+## Design decisions (settled)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Source switching | **Rebuild the pipeline when the ingress mode changes** | Selecting a source never touches the pipeline today (`relay_controller_select` just moves an index). UDP↔SHM changes which element chain must run, so it needs a rebuild. Reuses `uv_viewer_restart_pipeline` (`viewer_core.c:136`). Rejected: dual branch + `input-selector` — seamless, but carries a permanently idle branch and switch-time caps/PTS discontinuities. |
+| Listing | **Appear on successful attach** | Mirrors UDP peer auto-discovery. A source you cannot play should not be in the list. |
+| Stats | **Re-derive what the ring supports, blank the rest** | Zeroed RTP loss/jitter would read as a perfect link. |
+| Source identity | **A normal slot in `RelayController.sources[]`, tagged with a kind** | The table is append-only (`sources_count` + `in_use`, no removal/compaction — `relay_controller.c:400`), so indices are stable. The dropdown (`gui_shell.c`), CLI (`cli_shell.c`), and `uv_viewer_select_source` (`viewer_core.c:204`) then need **zero** index-space changes. |
+| ABI header | **A C11 mirror of the VFRM layout, checked with `_Static_assert`** | waybeam-link's `frame_shm_format.h` is C++ (`constexpr`, default member initialisers) and cannot be included from C11. |
+
+`RelayController` becomes the *source registry* (it already is, in practice) while
+staying the *UDP* reader; the SHM reader is a separate peer module.
+
+## Step 1 — VFRM ABI header
+
+**New:** `include/frame_shm_format.h`.
+
+Plain-C mirror of `protocols/frame-shm.md`: magic/version, header field offsets,
+`slot_count`/`slot_data_size` defaults, `align8` stride helper, and
+
+```c
+typedef struct { uint32_t pts; uint8_t codec; uint8_t flags; uint16_t reserved; } VencFrameMeta;
+_Static_assert(sizeof(VencFrameMeta) == 8, "VencFrameMeta must be 8 bytes");
+```
+
+plus `UV_FRAME_CODEC_H265 (0x01)` and `UV_FRAME_FLAG_IDR (0x01)`. Offsets stay
+byte-literal constants (not a struct) so no packing assumptions can drift.
+
+*Verify:* `make` — header compiles standalone in C11; offsets match
+`protocols/frame-shm.md` §Header by inspection.
+
+## Step 2 — SHM reader module
+
+**New:** `src/shm_ingress.c` (+ declarations in `src/uv_internal.h`).
+Model it 1:1 on `SidecarController` (`src/sidecar.c`): own thread, own `GMutex`,
+`_init` / `_start` / `_stop` / `_deinit` / `_snapshot`.
+
+```c
+typedef struct {
+    char      name[UV_SHM_NAME_MAX];   /* normalised to a leading '/' */
+    gboolean  enabled;
+    /* mapping */
+    void     *base; size_t map_size;
+    uint32_t  slot_count, slot_data_size; size_t stride;
+    dev_t     st_dev; ino_t st_ino;    /* captured at attach, for restart detect */
+    gboolean  attached;
+    /* thread */
+    GThread  *thread; volatile gboolean stop;
+    GMutex    lock;
+    /* sink */
+    GstAppSrc *appsrc;                 /* set/cleared like relay_controller_set_appsrc */
+    RelayController *registry;         /* to register the source + push stats */
+    /* counters */
+    uint64_t frames, bytes, full_drops_seen, oversize_drops, bad_slots, reattaches;
+} ShmIngress;
+```
+
+Thread loop:
+
+1. **Not attached** → try attach (R1) every 500 ms. On success: capture
+   `(st_dev, st_ino)`, register the source (Step 3), emit `SOURCE_ADDED`.
+2. **Attached** → drain: acquire-load `write_idx`; while `read_idx != write_idx`,
+   copy `length`, reject `length > slot_data_size` (`bad_slots++`, advance
+   `read_idx`, continue), copy `[meta][annex-b]`, release-store `read_idx+1`.
+3. **Empty** → park on the futex: store `consumer_waiting = 1` (SEQ_CST), load
+   `futex_seq`, `FUTEX_WAIT` (**shared**, no `PRIVATE` flag) with a 100 ms
+   timeout, store `consumer_waiting = 0`. The timeout tick both closes the
+   store/load race and gives us a place to run the restart check.
+4. **Starved ≥ 500 ms** → re-`shm_open` + `fstat`; if `(st_dev, st_ino)` differs
+   or `init_complete != 1` → `munmap`, mark detached, `reattaches++`, go to 1.
+   Never `shm_unlink` (R7/Constraints).
+
+Per frame: validate `meta.codec == UV_FRAME_CODEC_H265` (else drop, count),
+strip the 8 bytes, `gst_buffer_fill` a new buffer with the Annex-B body,
+`gst_app_src_push_buffer`. Do **not** set `GST_BUFFER_PTS` from `meta.pts` — it is
+a wrapping encoder clock and survives neither a wrap nor a producer restart;
+let `appsrc do-timestamp=TRUE is-live=TRUE format=TIME` stamp on arrival, and keep
+`meta.pts`/`meta.flags` for stats only.
+
+Reference consumer to crib from: `waybeam-link/tools/frame_shm_gst_bench.cpp:134-224`
+(attach → `read_frame` → strip meta → `gst_app_src_push_buffer`) and
+`waybeam-link/io/src/frame_shm.cpp:150-345` (attach validation, read loop, futex
+protocol, `backing_object_current()`).
+
+*Verify:* build clean; with `frame_shm_gst_bench` (or venc's
+`tools/frame_shm_consumer_test`) producing into a scratch ring, a debug log line
+per frame shows monotonic frames with plausible sizes and IDR flags.
+
+## Step 3 — Source registry: a kind tag
+
+**Edit:** `src/uv_internal.h` (`UvRelaySource`, ~line 28) — add
+`UvSourceKind kind;` (`UV_SOURCE_UDP` / `UV_SOURCE_SHM`) and a
+`char label[UV_VIEWER_ADDR_MAX];` used verbatim for SHM (`shm:/venc_frame_out`);
+UDP keeps formatting from `addr`.
+
+**Edit:** `src/relay_controller.c` — new
+`int relay_controller_register_shm(RelayController *rc, const char *label)`:
+takes `rc->lock`, appends an `in_use` slot with `kind = UV_SOURCE_SHM`, emits
+`UV_VIEWER_EVENT_SOURCE_ADDED`, returns the index. Plus
+`void relay_controller_shm_frame(RelayController *rc, int idx, const uint8_t *au, size_t len, const VencFrameMeta *meta)`
+which updates that slot's `rx_bytes`, bitrate EMA, `last_seen_us`, marker-frame
+counter (one AU = one marker frame — reuse the existing
+`source_record_marker_frame()` path so input-FPS lights up unchanged) and walks
+Annex-B start codes for the HEVC NAL counters (`(byte >> 1) & 0x3F` — same
+extraction the RFC 7798 walker already does at `relay_controller.c:620`).
+
+**Edit:** `uv_internal_populate_source_stats` (`src/relay_controller.c`, declared
+`uv_internal.h:281`) — for `UV_SOURCE_SHM`, leave the RTP-only fields at a
+sentinel (`-1` / `UINT64_MAX`) so the GUI can print `—` instead of `0`.
+
+**Edit:** `include/uv_viewer.h` (`UvSourceStats`, line 67) — add
+`UvSourceKind kind;` and the ring-health block (`shm_attached`, `shm_fill_pct`,
+`shm_full_drops`, `shm_oversize_drops`, `shm_bad_slots`, `shm_reattaches`).
+`shm_ingress` fills these via a snapshot under its own lock.
+
+*Verify:* run with no producer → source list unchanged from today. Start a
+producer → an `N: shm:/venc_frame_out` row appears in the dropdown and CLI `l`.
+
+## Step 4 — Pipeline: the Annex-B ingress branch
+
+**Edit:** `src/pipeline_builder.c`, `build_pipeline` (line 394) and the
+`PipelineController` struct.
+
+Add `UvIngressMode ingress_mode` to `PipelineController`. Branch element creation
+and linking:
+
+- `UV_INGRESS_UDP` (today, unchanged):
+  `appsrc(application/x-rtp) → queue_ingress → tee → cf_rtp_video → jbuf_video → depay → h265parse → h265caps → decoder → …`
+- `UV_INGRESS_SHM`:
+  `appsrc(video/x-h265,stream-format=byte-stream,alignment=au) → queue_ingress → h265parse → h265caps → decoder → …`
+
+Keep `queue_ingress` in both (its stats feed `stats->queue0`) and keep everything
+from `h265caps` downstream **byte-identical**, so the decoder src pad probe
+(`pipeline_builder.c:218`, installed ~:863) and the caps-change/sink-bounce
+recovery keep working untouched. The caps string already exists at
+`pipeline_builder.c:571`. SHM `appsrc`: `is-live=TRUE`, `format=TIME`,
+`do-timestamp=TRUE`.
+
+`on_need_data`/`on_enough_data` (`:262`) currently call
+`relay_controller_set_push_enabled()` — in SHM mode they must gate the SHM feeder
+instead. Route both through a mode-aware `pipeline_set_push_enabled()`.
+
+*Verify:* `GST_DEBUG=3` shows no "not-linked"/"not-negotiated"; the SHM branch
+reaches PLAYING and the decoder pad probe reports FPS.
+
+## Step 5 — Wiring and mode switching
+
+**Edit:** `src/viewer_core.c`.
+
+- `uv_viewer_new` (:44) — `shm_ingress_init` after `sidecar_controller_init`;
+  hand it `&viewer->relay` as the registry.
+- `uv_viewer_start` (:82) — instead of unconditionally
+  `relay_controller_set_appsrc(pipeline_controller_get_appsrc(...))` at **:95**,
+  wire the appsrc to the reader that matches the current ingress mode and pass
+  `NULL` to the other. Start the SHM reader whenever `shm_enabled` (it must run
+  even when a UDP source is selected — otherwise the ring never attaches and
+  never appears in the list).
+- `uv_viewer_stop` (:110) — stop the SHM reader in the sidecar/relay order.
+- `uv_viewer_restart_pipeline` (:136) — same use-after-free discipline the relay
+  already gets: `shm_ingress_set_appsrc(NULL)` **before** `pipeline_controller_deinit`
+  (the comment at :152 explains why), re-wire after re-init at :181.
+- `uv_viewer_select_source` (:204) — new logic:
+
+  ```c
+  UvSourceKind k = relay_controller_source_kind(&viewer->relay, index);
+  UvIngressMode want = (k == UV_SOURCE_SHM) ? UV_INGRESS_SHM : UV_INGRESS_UDP;
+  if (want != pipeline_controller_ingress_mode(&viewer->pipeline)) {
+      pipeline_controller_set_ingress_mode(&viewer->pipeline, want);
+      if (!uv_viewer_restart_pipeline(viewer, error)) return FALSE;   /* rewires appsrc */
+  }
+  return relay_controller_select(&viewer->relay, index, error);       /* unchanged */
+  ```
+
+  Failure to restart leaves the previous source selected and surfaces
+  `UV_VIEWER_EVENT_PIPELINE_ERROR` — do not leave a half-torn pipeline selected.
+
+*Verify:* select SHM → UDP → SHM in a loop 10×; video returns each time, no
+leaked threads (`ls /proc/$(pidof udp-h265-viewer)/task | wc -l` stable), no
+GStreamer criticals.
+
+## Step 6 — Config and Settings UI
+
+**Edit:** `include/uv_viewer.h` `UvViewerConfig` (line 33) — append
+`gboolean shm_enabled;` and `char shm_name[UV_SHM_NAME_MAX];`
+(default: disabled, `venc_frame_out`). **Edit:** `src/main.c` argv parsing —
+`--shm-name <name>` / `--shm` to match the CLI-first config pattern.
+
+**Edit:** `src/gui_shell.c` — a "SHM Ingress" section in `build_settings_page`
+(:3252), following the Restream block verbatim: a `.uv-info` header label with
+`margin-top 6` spanning both columns, then `GtkCheckButton *shm_toggle` and
+`GtkEntry *shm_name_entry` (placeholder `venc_frame_out`, tooltip naming
+`/dev/shm/<name>`) at grid col 1, on the rows after Restream. Then:
+
+1. widgets on `GuiContext` (near the settings widgets at :53-71);
+2. cfg → widgets in `sync_settings_controls`;
+3. widgets → `new_cfg` in `on_settings_apply_clicked` (:2870);
+4. **add both fields to the "settings unchanged" equality short-circuit**
+   (~:2780-2802) — otherwise changing only the ring name silently does nothing.
+   This is the step that gets forgotten;
+5. NULL the pointers in `on_app_shutdown`.
+
+Grey out the Restream controls and the sidecar panel while the selected source is
+`UV_SOURCE_SHM` (non-goals), and render RTP-only stat cells as `—` on the
+sentinel values from Step 3. Add the ring-health readout to the Stats tab.
+
+*Verify:* change only the ring name → Apply → the viewer rebuilds and attaches to
+the new object. Restream toggle is insensitive while SHM is selected.
+
+## Step 7 — Build
+
+**Edit:** `Makefile` — add `src/shm_ingress.c` to `SRCS` (:18-26); add `-lrt` and
+`-pthread` to the link line (:34) and `-pthread` to `CFLAGS`. `_GNU_SOURCE` is set
+in `shm_ingress.c` only (the pattern `cli_shell.c:1` already uses), not globally.
+
+*Verify:* `make clean && make 2>&1 | grep -E '(error|warning)'` is empty
+(`-Wall -Wextra` is already on).
+
+## Risks
+
+- **Latency.** waybeam-link emits a frame the instant its FEC block decodes; it
+  does no pacing. With `do-timestamp` + a live appsrc and `sync_to_clock=false`,
+  frames should render immediately. If the sink instead builds a growing latency
+  queue, revisit `is-live`/`sync` before adding a jitter buffer — a frame ring has
+  nothing to jitter-buffer.
+- **Slot size.** 512 KiB per slot; a 4K IDR at high bitrate can exceed it and the
+  *producer* drops that frame (`oversize_drops`). We can only report it.
+- **Futex is shared, not private.** Using `FUTEX_PRIVATE_FLAG` would silently
+  never wake (different keying). Polling with a short sleep is an acceptable
+  fallback if the futex path misbehaves — the bench does exactly that.
+- **`sources_count` is monotonic.** A ring that attaches, drops, and re-attaches
+  must reuse its slot, not append a second one. Key the reuse on the label.
+
+## Follow-ups (outside this branch)
+
+- Coordination repo: add radeon-vrx to the consumer table in
+  `protocols/frame-shm.md` and to `roadmaps/radeon-vrx.md`.
+- Sidecar-host override so venc telemetry works for a SHM source.
+- RTP-packetised restream for SHM sources.

--- a/specs/2026-07-12-shm-ingress/requirements.md
+++ b/specs/2026-07-12-shm-ingress/requirements.md
@@ -1,0 +1,148 @@
+# SHM ingress — requirements
+
+Status: DRAFT (not implemented)
+Branch: `feature/shm-ingress`
+Date: 2026-07-12
+
+## Problem
+
+radeon-vrx can only ingest RTP over UDP. When the ground link is
+[waybeam-link](https://github.com/snokvist/waybeam-link) running a `frame-shm`
+RX egress, the received video never becomes RTP: waybeam-link reassembles whole
+Annex-B access units (FEC-decoded at frame boundaries) and publishes them into a
+POSIX shared-memory ring. There is no UDP datagram to listen to, so today that
+stream is undisplayable in radeon-vrx.
+
+The waybeam-link RX egress is configured as:
+
+```json
+"streams": [
+  { "stream_id": 0, "stream_type": "RTP", "dir": "out", "originator": 17,
+    "bind": { "kind": "frame-shm", "name": "venc_frame_out" } }
+]
+```
+
+which publishes the POSIX object `/venc_frame_out` (`/dev/shm/venc_frame_out`).
+
+## Goal
+
+Consume that ring directly, decode it, and present it as a normal entry in the
+existing **Sources** list next to the auto-discovered UDP peers — same dropdown,
+same selection model, same stats surface where the stats still mean something.
+
+## Wire contract (fixed — do not renegotiate)
+
+The ring is the **VFRM** format, canonically specified in the coordination repo
+at `protocols/frame-shm.md`, mirrored in waybeam-link at
+`core/include/wblink/frame_shm_format.h` and produced by waybeam_venc's
+`include/venc_frame_ring.h`. radeon-vrx is a **pure consumer** and must not
+extend it.
+
+- Object: `/<name>`, mmap'd `MAP_SHARED`. Native-endian, same-host only.
+- Header: 192 bytes. magic `0x5646524D` ("VFRM") @0, version `1` @4,
+  `slot_count` @8 (power of two, default 16), `slot_data_size` @12
+  (default 512 KiB, **includes** the 8-byte meta), `total_size` @16,
+  `epoch` @20, `init_complete` @24, `write_idx` u64 @64, `futex_seq` u32 @72,
+  `read_idx` u64 @128, `consumer_waiting` u32 @136.
+- Slot stride: `align8(4 + slot_data_size)` (= 524296 by default);
+  slot `i` at `192 + i*stride`, laid out `[u32 length][VencFrameMeta 8B][Annex-B …]`.
+  `length` counts the meta **plus** the frame bytes.
+- `VencFrameMeta`: `pts` u32 @0 (encoder clock, ms-ish, **wraps**),
+  `codec` u8 @4 (`0x01` = H.265, only value emitted), `flags` u8 @5
+  (bit 0 = IDR), `reserved` u16 @6 (must be 0).
+- Payload: one complete access unit, raw Annex-B with start codes preserved.
+  Never a partial frame.
+- SPSC: acquire-load `write_idx`, read slot at `read_idx & (slot_count-1)`,
+  release-store `read_idx+1`. Indices are free-running u64 counters.
+- Wake: producer bumps `futex_seq` and, if `consumer_waiting != 0`, issues a
+  **shared** (not `FUTEX_PRIVATE_FLAG`) `FUTEX_WAKE` on `futex_seq`.
+- Backpressure is **drop, never block** — a slow consumer loses frames, it never
+  stalls the link.
+
+## Functional requirements
+
+**R1 — Attach.** Given a configured ring name, a background reader attaches to
+`/<name>`: `shm_open(O_RDWR)` → `fstat` → `mmap` → acquire-load `init_complete`
+→ validate magic, version, power-of-two `slot_count`, nonzero `slot_data_size`,
+and `192 + slot_count*align8(4+slot_data_size) == st_size == total_size`.
+Any failure is a non-fatal "not attached" state that is retried.
+
+**R2 — Appear as a Source.** On successful attach the ring is registered in the
+existing source table and emits `UV_VIEWER_EVENT_SOURCE_ADDED`, so it shows up in
+the GUI dropdown and the CLI `l`/`s <index>` commands with no change to those
+call sites. Its display identity is `shm:/<name>` (occupying the `address` field).
+It is **not** listed while unattached.
+
+**R3 — Decode.** Selecting the SHM source plays it: frames are pushed, meta
+stripped, into an `appsrc` with caps
+`video/x-h265,stream-format=byte-stream,alignment=au`, through `h265parse` into
+the same decoder + sink chain the UDP path already uses. The RTP-only elements
+(tee, RTP capsfilter, `rtpjitterbuffer`, `rtph265depay`) are **not** in the SHM
+chain.
+
+**R4 — Switching.** Selecting a source whose kind differs from the running
+ingress mode rebuilds the pipeline with the correct ingress branch. UDP↔UDP
+selection stays instant and pipeline-free, exactly as today. A UDP↔SHM switch may
+cost a decoder re-init and a black frame; it must not leak, dangle the `appsrc`,
+or wedge either reader thread.
+
+**R5 — Settings.** The ring name is user-settable in the Settings tab (text
+entry, default `venc_frame_out`), alongside an enable toggle. The name
+participates in the "settings unchanged" equality short-circuit so that changing
+only the name still rebuilds. A leading `/` is optional and normalised.
+
+**R6 — Stats.** For the SHM source, re-derive what the ring can support and
+blank what it cannot:
+- *Derived:* frames/s (one AU = one frame), frame size, inbound bitrate, HEVC NAL
+  composition and `seconds_since_keyframe` (parse Annex-B start codes directly;
+  NAL type = `(byte >> 1) & 0x3F`), time since last frame.
+- *Blank (`—`), never zero:* `rtp_lost/duplicate/reordered/expected`,
+  `rfc3550_jitter_ms`, `rtp_ap_packets`, `rtp_fu_packets`. Zeros would read as
+  "a perfect link", which is a lie.
+- *New:* ring health — attached/stale, fill %, `full_drops`, `oversize_drops`,
+  `bad_slots`, reattach count.
+- *Unchanged:* decoder FPS and QoS (pad probe + bus messages are ingress-agnostic).
+
+**R7 — Producer restart.** waybeam-link `shm_unlink`s and re-creates the object
+on restart, so an attached consumer keeps mapping a dead orphan inode. The reader
+must detect this — re-`shm_open` the name and compare `(st_dev, st_ino)` against
+the values captured at attach, plus `init_complete` — then `munmap` and re-attach.
+Detection is polled while starved (no frames for ~500 ms), not per frame.
+
+**R8 — Robustness.** No producer, a stale/garbage ring, a corrupt slot
+(`length > slot_data_size`), or a producer that vanishes mid-stream must all
+degrade gracefully: the viewer stays alive, the UDP path keeps working, and the
+SHM source drops out of "attached". A corrupt slot is skipped by advancing
+`read_idx` — never stall on it.
+
+## Non-goals (v1)
+
+- **Restream for SHM sources.** Restream (#24) is a verbatim *datagram* copy taken
+  in the relay recv loop; a frame ring has no datagrams. The toggle is greyed out
+  while a SHM source is selected. RTP-packetising frames to restream them is a
+  separate feature.
+- **Sidecar telemetry for SHM sources.** The sidecar controller targets the
+  selected source's IP; a ring has none. It goes inert. (A future "sidecar host"
+  override could restore it.)
+- **Writing to the ring / multiple consumers.** SPSC — one consumer, read-only
+  intent. Producing a ring is out of scope.
+- **Codecs other than H.265.** `codec != 0x01` is counted as bad meta and dropped.
+- **Configurable ring geometry.** The producer owns geometry; we read it from
+  the header.
+- **Audio.** The frame-shm egress is video-only.
+
+## Constraints
+
+- C11, GTK4/GStreamer, hand-written Makefile. New TU needs `_GNU_SOURCE`
+  (`syscall(SYS_futex, …)`); link needs `-lrt` (`shm_open`) and explicit
+  `-pthread` if raw pthreads are used — neither is linked today.
+- Worker→GTK marshalling is `g_idle_add` only (see `sidecar.c`); do not touch GTK
+  from the reader thread.
+- The producer is the ring's owner. radeon-vrx must **never** `shm_unlink` it.
+
+## Acceptance
+
+See `validation.md`. Headline: with waybeam-link RX running a `frame-shm` egress,
+the ring appears in the Sources dropdown, plays at the producer's frame rate with
+no persistent artefacts, survives a producer restart without operator action, and
+UDP sources continue to work unchanged in the same session.

--- a/specs/2026-07-12-shm-ingress/validation.md
+++ b/specs/2026-07-12-shm-ingress/validation.md
@@ -1,0 +1,50 @@
+# SHM ingress — validation
+
+Each check maps to a requirement in `requirements.md`. A step is done only when
+its check passes.
+
+## Rigs
+
+**A — Bench, no radio (fast loop).** A local producer writes a VFRM ring; only
+radeon-vrx is under test.
+
+```bash
+# waybeam-link's bench producer (also the reference consumer for the format)
+cd ~/dev/waybeam-link && cmake --build build --target frame_shm_gst_bench
+./build/frame_shm_gst_bench --produce --name venc_frame_out    # or tools/frame_shm_udp_bench.sh
+ls -l /dev/shm/venc_frame_out                                  # ~8 MB, 16 x 512 KiB
+```
+
+**B — Real link.** waybeam_venc (`outgoing.server = frame-shm://venc_frames`) →
+`waybeam-link tx` on the vehicle → `waybeam-link rx` on this host with
+`"bind": {"kind":"frame-shm","name":"venc_frame_out"}` (see
+`waybeam-link/examples/config.frame-shm-rx.sample.json`). Cross-check the link's
+own view via `GET :8091/api/v1/stats` (`frames_fast`, `shm_full_drops`,
+`dropped_deadline`).
+
+## Checks
+
+| # | Req | Check | Pass |
+|---|---|---|---|
+| V1 | R1 | Start viewer with no producer, then start one | No error, no crash; source appears within ~1 s of the producer starting |
+| V2 | R1/R8 | Point the ring name at a bogus object, then at a truncated/garbage file in `/dev/shm` | Stays unattached, logs a validation failure, UDP path unaffected, no crash |
+| V3 | R2 | Rig A running | `shm:/venc_frame_out` is in the GUI dropdown and CLI `l`, at a stable index alongside UDP peers |
+| V4 | R3 | Select the SHM source | Video plays; decoder pad probe reports FPS within ±1 of the producer's rate; no persistent artefacts after the first IDR |
+| V5 | R4 | Loop select SHM → UDP → SHM 10× with both live | Video returns every time; thread count stable (`ls /proc/$(pidof udp-h265-viewer)/task \| wc -l`); zero GStreamer criticals; UDP↔UDP switching still causes no pipeline restart |
+| V6 | R5 | Change only the ring name in Settings → Apply | Viewer rebuilds and attaches to the new object (guards against the "settings unchanged" short-circuit trap) |
+| V7 | R6 | SHM source selected, Stats tab | frames/s, frame size, bitrate, NAL counts, `seconds_since_keyframe` are live and plausible; RTP loss/jitter/FU/AP show `—`, **not** `0`; ring health (fill %, `full_drops`, `bad_slots`) is shown |
+| V8 | R6 | Force IDRs at the producer (venc `GET /request/idr` ×3) | `hevc_idr_count` rises by exactly 3; `seconds_since_keyframe` resets |
+| V9 | R7 | `SIGTERM` the producer, restart it, leave the viewer running | Source goes stale, then re-attaches on its own; `reattaches` increments; video resumes with no operator action |
+| V10 | R8 | `SIGKILL` the producer mid-stream | Viewer survives, drops to unattached, no busy-spin (CPU of the reader thread ~0), UDP sources keep playing |
+| V11 | R8 | Stall the consumer (pause the viewer process ~2 s with `SIGSTOP`, then `SIGCONT`) | Producer's `full_drops` rises; viewer recovers on the next IDR; the link is never blocked |
+| V12 | Non-goal | SHM source selected | Restream toggle and sidecar panel are greyed out (not silently no-op) |
+| V13 | R3 | Rig B, 5-minute run | Frame count delivered to the decoder matches waybeam-link's `frames_fast + frames_recovered` minus its own `shm_full_drops`, within the drop counters we report |
+| V14 | — | Build | `make clean && make` emits no warnings (`-Wall -Wextra` already on) |
+| V15 | — | Leaks | `valgrind --leak-check=full` (or ASan) over a start → SHM select → UDP select → quit cycle: no leaks from the reader, no use-after-free on the appsrc across the restart |
+
+## Regression guard
+
+The UDP path must be untouched. Re-run the pre-existing manual smoke with a plain
+venc RTP sender: sources discover, select, stats populate, restream forwards,
+sidecar telemetry arrives — all identical to `main`. Any behaviour change on the
+UDP side is a bug in this branch, not a trade-off.

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -86,6 +86,8 @@ typedef struct {
     GtkSpinButton  *restream_port_spin;
     GtkLabel       *restream_status_label;
     gboolean        restream_toggle_suppress;
+    GtkCheckButton *shm_toggle;
+    GtkEntry       *shm_name_entry;
     GtkNotebook *notebook;
     GtkDropDown *stats_range_dropdown;
     GtkDrawingArea *stats_charts[STATS_METRIC_COUNT];
@@ -1848,6 +1850,10 @@ static void sync_settings_controls(GuiContext *ctx) {
             gtk_widget_set_sensitive(GTK_WIDGET(ctx->restream_port_spin), !on);
         }
     }
+    if (ctx->shm_toggle) check_set(ctx->shm_toggle, ctx->current_cfg.shm_enabled);
+    if (ctx->shm_name_entry) {
+        gtk_editable_set_text(GTK_EDITABLE(ctx->shm_name_entry), ctx->current_cfg.shm_name);
+    }
     if (ctx->decoder_dropdown) {
         gtk_drop_down_set_selected(ctx->decoder_dropdown,
                                    decoder_pref_to_index(ctx->current_cfg.decoder_preference));
@@ -3367,11 +3373,17 @@ static void refresh_stats(GuiContext *ctx) {
             if (detail_source) {
                 char rate_buf[64];
                 format_bitrate(detail_source->inbound_bitrate_bps, rate_buf, sizeof(rate_buf));
-                char detail[320];
+                char detail[512];
+                char jitter_buf[32];
+                if (detail_source->kind == UV_SOURCE_SHM)
+                    g_strlcpy(jitter_buf, "—", sizeof(jitter_buf));
+                else
+                    g_snprintf(jitter_buf, sizeof(jitter_buf), "%.2fms",
+                               detail_source->rfc3550_jitter_ms);
                 g_snprintf(detail, sizeof(detail),
                            "%u: %s\nrx=%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT
                            " fwd=%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT
-                           " rate=%s input_fps=%.2f jitter=%.2fms last_seen=%.1fs",
+                           " rate=%s input_fps=%.2f jitter=%s last_seen=%.1fs",
                            detail_index,
                            detail_source->address,
                            detail_source->rx_packets,
@@ -3380,8 +3392,20 @@ static void refresh_stats(GuiContext *ctx) {
                            detail_source->forwarded_bytes,
                            rate_buf,
                            detail_source->rtp_marker_fps,
-                           detail_source->rfc3550_jitter_ms,
+                           jitter_buf,
                            detail_source->seconds_since_last_seen >= 0.0 ? detail_source->seconds_since_last_seen : 0.0);
+                if (detail_source->kind == UV_SOURCE_SHM) {
+                    char ring[192];
+                    g_snprintf(ring, sizeof(ring),
+                               "\nring=%s fill=%.1f%% full=%" G_GUINT64_FORMAT
+                               " oversize=%" G_GUINT64_FORMAT " bad=%" G_GUINT64_FORMAT
+                               " reattaches=%" G_GUINT64_FORMAT,
+                               detail_source->shm_attached ? "attached" : "stale",
+                               detail_source->shm_fill_pct, detail_source->shm_full_drops,
+                               detail_source->shm_oversize_drops, detail_source->shm_bad_slots,
+                               detail_source->shm_reattaches);
+                    g_strlcat(detail, ring, sizeof(detail));
+                }
                 if (waiting_for_switch) {
                     char switching[320];
                     g_snprintf(switching, sizeof(switching), "Switching to %s", detail);
@@ -3392,7 +3416,8 @@ static void refresh_stats(GuiContext *ctx) {
 
                 if (ctx->stream_detail_label) {
                     uint64_t kf_total = detail_source->hevc_idr_count + detail_source->hevc_cra_count;
-                    uint64_t total_pkts = detail_source->rtp_unique_packets;
+                    uint64_t total_pkts = detail_source->kind == UV_SOURCE_SHM
+                                        ? 0 : detail_source->rtp_unique_packets;
                     double frag_pct = (total_pkts > 0)
                                     ? (100.0 * (double)detail_source->rtp_fu_packets / (double)total_pkts)
                                     : 0.0;
@@ -3415,12 +3440,22 @@ static void refresh_stats(GuiContext *ctx) {
                                    detail_source->last_keyframe_interval_seconds);
                     }
                     char stream_detail[384];
+                    char ap_buf[32], fu_buf[32];
+                    if (detail_source->kind == UV_SOURCE_SHM) {
+                        g_strlcpy(ap_buf, "—", sizeof(ap_buf));
+                        g_strlcpy(fu_buf, "—", sizeof(fu_buf));
+                    } else {
+                        g_snprintf(ap_buf, sizeof(ap_buf), "%" G_GUINT64_FORMAT,
+                                   detail_source->rtp_ap_packets);
+                        g_snprintf(fu_buf, sizeof(fu_buf), "%" G_GUINT64_FORMAT,
+                                   detail_source->rtp_fu_packets);
+                    }
                     g_snprintf(stream_detail, sizeof(stream_detail),
                                "HEVC  IDR=%" G_GUINT64_FORMAT "  CRA=%" G_GUINT64_FORMAT
                                "  trail=%" G_GUINT64_FORMAT "  VPS/SPS/PPS=%" G_GUINT64_FORMAT
                                "/%" G_GUINT64_FORMAT "/%" G_GUINT64_FORMAT
                                "  SEI=%" G_GUINT64_FORMAT "  AUD=%" G_GUINT64_FORMAT
-                               "  •  AP=%" G_GUINT64_FORMAT "  FU=%" G_GUINT64_FORMAT
+                               "  •  AP=%s  FU=%s"
                                " (%.1f%% frag)"
                                "  •  KF total=%" G_GUINT64_FORMAT "  last %s ago  Δ %s",
                                detail_source->hevc_idr_count,
@@ -3431,14 +3466,28 @@ static void refresh_stats(GuiContext *ctx) {
                                detail_source->hevc_pps_count,
                                detail_source->hevc_sei_count,
                                detail_source->hevc_aud_count,
-                               detail_source->rtp_ap_packets,
-                               detail_source->rtp_fu_packets,
+                               ap_buf,
+                               fu_buf,
                                frag_pct,
                                kf_total,
                                kf_age_buf,
                                kf_gap_buf);
                     gtk_label_set_text(ctx->stream_detail_label, stream_detail);
                 }
+                gboolean udp_controls = detail_source->kind != UV_SOURCE_SHM;
+                if (ctx->restream_toggle)
+                    gtk_widget_set_sensitive(GTK_WIDGET(ctx->restream_toggle), udp_controls);
+                if (ctx->restream_host_entry)
+                    gtk_widget_set_sensitive(GTK_WIDGET(ctx->restream_host_entry),
+                                             udp_controls && !ctx->current_cfg.restream_enabled);
+                if (ctx->restream_port_spin)
+                    gtk_widget_set_sensitive(GTK_WIDGET(ctx->restream_port_spin),
+                                             udp_controls && !ctx->current_cfg.restream_enabled);
+                if (ctx->sidecar_enable_toggle)
+                    gtk_widget_set_sensitive(GTK_WIDGET(ctx->sidecar_enable_toggle), udp_controls);
+                if (ctx->sidecar_port_spin)
+                    gtk_widget_set_sensitive(GTK_WIDGET(ctx->sidecar_port_spin),
+                                             udp_controls && !ctx->current_cfg.sidecar_enabled);
             } else if (waiting_for_switch) {
                 char message[128];
                 g_snprintf(message, sizeof(message), "Switching to source %u...", detail_index);
@@ -3477,9 +3526,10 @@ static void refresh_stats(GuiContext *ctx) {
         StatsSample sample = {0};
         sample.timestamp = g_get_monotonic_time() / 1e6;
         sample.rate_bps = viewer_selected_source->inbound_bitrate_bps;
-        sample.lost_packets = (double)viewer_selected_source->rtp_lost_packets;
-        sample.dup_packets = (double)viewer_selected_source->rtp_duplicate_packets;
-        sample.reorder_packets = (double)viewer_selected_source->rtp_reordered_packets;
+        gboolean shm_source = viewer_selected_source->kind == UV_SOURCE_SHM;
+        sample.lost_packets = shm_source ? NAN : (double)viewer_selected_source->rtp_lost_packets;
+        sample.dup_packets = shm_source ? NAN : (double)viewer_selected_source->rtp_duplicate_packets;
+        sample.reorder_packets = shm_source ? NAN : (double)viewer_selected_source->rtp_reordered_packets;
         sample.rx_packets = (double)viewer_selected_source->rx_packets;
         sample.rx_bytes = (double)viewer_selected_source->rx_bytes;
         if (ctx->stats_history && ctx->stats_history->len > 0) {
@@ -3502,7 +3552,7 @@ static void refresh_stats(GuiContext *ctx) {
                                             ? dbytes_rx / dpkts : 0.0;
             }
         }
-        sample.jitter_ms = viewer_selected_source->rfc3550_jitter_ms;
+        sample.jitter_ms = shm_source ? NAN : viewer_selected_source->rfc3550_jitter_ms;
         sample.input_fps = viewer_selected_source->rtp_marker_fps;
         sample.decoder_fps_current = stats.decoder.instantaneous_fps;
         double latest_lateness = NAN;
@@ -4068,6 +4118,8 @@ static gboolean gui_restart_with_config_ex(GuiContext *ctx,
         cfg->audio_jitter_latency_ms == ctx->current_cfg.audio_jitter_latency_ms &&
         cfg->audio_use_separate_port == ctx->current_cfg.audio_use_separate_port &&
         cfg->audio_listen_port == ctx->current_cfg.audio_listen_port &&
+        cfg->shm_enabled == ctx->current_cfg.shm_enabled &&
+        g_strcmp0(cfg->shm_name, ctx->current_cfg.shm_name) == 0 &&
         cfg->jitter_drop_on_latency == ctx->current_cfg.jitter_drop_on_latency &&
         cfg->jitter_do_lost == ctx->current_cfg.jitter_do_lost &&
         cfg->jitter_post_drop_messages == ctx->current_cfg.jitter_post_drop_messages) {
@@ -4180,6 +4232,13 @@ static void on_settings_apply_clicked(GtkButton *button, gpointer user_data) {
     new_cfg.jitter_drop_on_latency = check_get(ctx->jitter_drop_toggle);
     new_cfg.jitter_do_lost = check_get(ctx->jitter_do_lost_toggle);
     new_cfg.jitter_post_drop_messages = check_get(ctx->jitter_post_drop_toggle);
+    new_cfg.shm_enabled = check_get(ctx->shm_toggle);
+    if (ctx->shm_name_entry) {
+        const char *name = gtk_editable_get_text(GTK_EDITABLE(ctx->shm_name_entry));
+        while (name && *name == '/') name++;
+        g_strlcpy(new_cfg.shm_name, name && *name ? name : "venc_frame_out",
+                  sizeof(new_cfg.shm_name));
+    }
 
     if (ctx->idr_port_spin) {
         int port = gtk_spin_button_get_value_as_int(ctx->idr_port_spin);
@@ -4766,6 +4825,24 @@ static GtkWidget *build_settings_page(GuiContext *ctx) {
     gtk_label_set_selectable(ctx->restream_status_label, TRUE);
     gtk_widget_add_css_class(GTK_WIDGET(ctx->restream_status_label), "uv-source-detail");
     gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->restream_status_label), 0, 17, 2, 1);
+
+    GtkWidget *shm_header = gtk_label_new("SHM Ingress");
+    gtk_label_set_xalign(GTK_LABEL(shm_header), 0.0);
+    gtk_widget_add_css_class(shm_header, "uv-info");
+    gtk_widget_set_margin_top(shm_header, 6);
+    gtk_grid_attach(GTK_GRID(grid), shm_header, 0, 18, 2, 1);
+
+    ctx->shm_toggle = GTK_CHECK_BUTTON(gtk_check_button_new_with_label("Enable SHM ingress"));
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->shm_toggle), 0, 19, 2, 1);
+
+    GtkWidget *shm_name_label = gtk_label_new("Ring Name:");
+    gtk_label_set_xalign(GTK_LABEL(shm_name_label), 0.0);
+    gtk_grid_attach(GTK_GRID(grid), shm_name_label, 0, 20, 1, 1);
+    ctx->shm_name_entry = GTK_ENTRY(gtk_entry_new());
+    gtk_entry_set_placeholder_text(ctx->shm_name_entry, "venc_frame_out");
+    gtk_widget_set_tooltip_text(GTK_WIDGET(ctx->shm_name_entry),
+                                "POSIX object at /dev/shm/<name>; a leading slash is optional.");
+    gtk_grid_attach(GTK_GRID(grid), GTK_WIDGET(ctx->shm_name_entry), 1, 20, 1, 1);
 
     GtkWidget *apply_button = gtk_button_new_with_label("Apply Settings");
     gtk_widget_add_css_class(apply_button, "suggested-action");
@@ -6341,6 +6418,8 @@ static void on_app_shutdown(GApplication *app, gpointer user_data) {
     ctx->restream_port_spin = NULL;
     ctx->restream_status_label = NULL;
     ctx->restream_toggle_suppress = FALSE;
+    ctx->shm_toggle = NULL;
+    ctx->shm_name_entry = NULL;
 }
 
 int uv_gui_run(UvViewer **viewer, UvViewerConfig *cfg, const char *program_name) {

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,8 @@ static void print_usage(const char *argv0) {
                " [--decoder auto|intel|nvidia|vaapi|software]"
                " [--video-sink auto|gtk4|wayland|gl|xv|autovideo|fakesink]"
                " [--idr-port N] [--sidecar] [--no-sidecar] [--sidecar-port N]"
-               " [--restream HOST:PORT] [--no-restream]\n",
+               " [--restream HOST:PORT] [--no-restream]"
+               " [--shm] [--no-shm] [--shm-name NAME]\n",
                argv0);
 }
 
@@ -210,6 +211,18 @@ static gboolean parse_args(int argc, char **argv, UvViewerConfig *cfg) {
             cfg->restream_enabled = TRUE;
         } else if (!strcmp(argv[i], "--no-restream")) {
             cfg->restream_enabled = FALSE;
+        } else if (!strcmp(argv[i], "--shm")) {
+            cfg->shm_enabled = TRUE;
+        } else if (!strcmp(argv[i], "--no-shm")) {
+            cfg->shm_enabled = FALSE;
+        } else if (!strcmp(argv[i], "--shm-name") && i + 1 < argc) {
+            const char *name = argv[++i];
+            if (!name[0] || strlen(name) >= sizeof(cfg->shm_name)) {
+                g_printerr("Invalid SHM name: %s\n", name);
+                return FALSE;
+            }
+            g_strlcpy(cfg->shm_name, name, sizeof(cfg->shm_name));
+            cfg->shm_enabled = TRUE;
         } else if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
             print_usage(argv[0]);
             exit(EXIT_SUCCESS);

--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -262,13 +262,19 @@ static void remove_audio_probe(PipelineController *pc) {
 static void on_need_data(GstAppSrc *src, guint length, gpointer user_data) {
     (void)src; (void)length;
     PipelineController *pc = (PipelineController *)user_data;
-    relay_controller_set_push_enabled(&pc->viewer->relay, TRUE);
+    if (pc->ingress_mode == UV_INGRESS_SHM)
+        shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, TRUE);
+    else
+        relay_controller_set_push_enabled(&pc->viewer->relay, TRUE);
 }
 
 static void on_enough_data(GstAppSrc *src, gpointer user_data) {
     (void)src;
     PipelineController *pc = (PipelineController *)user_data;
-    relay_controller_set_push_enabled(&pc->viewer->relay, FALSE);
+    if (pc->ingress_mode == UV_INGRESS_SHM)
+        shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, FALSE);
+    else
+        relay_controller_set_push_enabled(&pc->viewer->relay, FALSE);
 }
 
 static gboolean pipeline_swap_to_fakesink(PipelineController *pc) {
@@ -395,11 +401,13 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
     UvViewer *viewer = pc->viewer;
     pc->appsrc_element   = gst_element_factory_make("appsrc", "src");
     pc->queue0           = gst_element_factory_make("queue", "queue_ingress");
-    pc->tee              = gst_element_factory_make("tee", "tee");
-    pc->queue_video_in   = gst_element_factory_make("queue", "queue_video_in");
-    pc->capsfilter_rtp_video = gst_element_factory_make("capsfilter", "cf_rtp_video");
-    pc->jitterbuffer     = gst_element_factory_make("rtpjitterbuffer", "jbuf_video");
-    pc->depay            = gst_element_factory_make("rtph265depay", "depay");
+    if (pc->ingress_mode == UV_INGRESS_UDP) {
+        pc->tee = gst_element_factory_make("tee", "tee");
+        pc->queue_video_in = gst_element_factory_make("queue", "queue_video_in");
+        pc->capsfilter_rtp_video = gst_element_factory_make("capsfilter", "cf_rtp_video");
+        pc->jitterbuffer = gst_element_factory_make("rtpjitterbuffer", "jbuf_video");
+        pc->depay = gst_element_factory_make("rtph265depay", "depay");
+    }
     pc->parser           = gst_element_factory_make("h265parse", "parser");
     pc->capsfilter       = gst_element_factory_make("capsfilter", "h265caps");
     pc->queue_postdec    = gst_element_factory_make("queue", "queue_postdec");
@@ -422,7 +430,7 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         pc->queue_postrate = gst_element_factory_make("queue", "queue_postrate");
     }
 
-    if (pc->audio_enabled) {
+    if (pc->audio_enabled && pc->ingress_mode == UV_INGRESS_UDP) {
         pc->queue_audio_in = gst_element_factory_make("queue", "queue_audio_in");
         pc->capsfilter_rtp_audio = gst_element_factory_make("capsfilter", "cf_rtp_audio");
         if (pc->audio_use_separate_port) {
@@ -520,8 +528,10 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         return FALSE;
     }
 
-    if (!pc->appsrc_element || !pc->queue0 || !pc->tee || !pc->queue_video_in ||
-        !pc->capsfilter_rtp_video || !pc->jitterbuffer || !pc->depay ||
+    if (!pc->appsrc_element || !pc->queue0 ||
+        (pc->ingress_mode == UV_INGRESS_UDP &&
+         (!pc->tee || !pc->queue_video_in || !pc->capsfilter_rtp_video ||
+          !pc->jitterbuffer || !pc->depay)) ||
         !pc->parser || !pc->capsfilter || !pc->decoder ||
         !pc->queue_postdec || !pc->video_convert ||
         (pc->use_videorate && (!pc->videorate || !pc->videorate_caps || !pc->queue_postrate))) {
@@ -561,10 +571,12 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         return FALSE;
     }
 
-    GstCaps *caps_appsrc = gst_caps_new_empty_simple("application/x-rtp");
+    GstCaps *caps_appsrc = pc->ingress_mode == UV_INGRESS_SHM
+                         ? gst_caps_from_string("video/x-h265,stream-format=byte-stream,alignment=au")
+                         : gst_caps_new_empty_simple("application/x-rtp");
     if (!caps_appsrc) {
         g_set_error(error, g_quark_from_static_string("uv-viewer"), 12,
-                    "Failed to build RTP caps");
+                    "Failed to build ingress caps");
         return FALSE;
     }
 
@@ -578,7 +590,8 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
 
     g_object_set(pc->appsrc_element,
                  "is-live", TRUE,
-                 "format", GST_FORMAT_BYTES,
+                 "format", pc->ingress_mode == UV_INGRESS_SHM ? GST_FORMAT_TIME : GST_FORMAT_BYTES,
+                 "do-timestamp", pc->ingress_mode == UV_INGRESS_SHM,
                  "block", FALSE,
                  "max-bytes", (guint64)(2 * 1024 * 1024),
                  "stream-type", GST_APP_STREAM_TYPE_STREAM,
@@ -602,27 +615,29 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
                      NULL);
     }
 
-    g_object_set(pc->jitterbuffer,
+    if (pc->jitterbuffer) g_object_set(pc->jitterbuffer,
                  "latency", (guint)MAX(viewer->config.jitter_latency_ms, 0u),
                  "drop-on-latency", viewer->config.jitter_drop_on_latency,
                  "do-lost", viewer->config.jitter_do_lost,
                  "post-drop-messages", viewer->config.jitter_post_drop_messages,
                  NULL);
 
-    GstCaps *caps_rtp_video = gst_caps_new_simple("application/x-rtp",
+    GstCaps *caps_rtp_video = pc->ingress_mode == UV_INGRESS_UDP ? gst_caps_new_simple("application/x-rtp",
                                                   "media", G_TYPE_STRING, "video",
                                                   "encoding-name", G_TYPE_STRING, "H265",
                                                   "payload", G_TYPE_INT, pc->payload_type,
                                                   "clock-rate", G_TYPE_INT, pc->clock_rate,
-                                                  NULL);
-    if (!caps_rtp_video) {
+                                                  NULL) : NULL;
+    if (pc->ingress_mode == UV_INGRESS_UDP && !caps_rtp_video) {
         gst_caps_unref(caps_h265);
         g_set_error(error, g_quark_from_static_string("uv-viewer"), 16,
                     "Failed to build video RTP caps");
         return FALSE;
     }
-    g_object_set(pc->capsfilter_rtp_video, "caps", caps_rtp_video, NULL);
-    gst_caps_unref(caps_rtp_video);
+    if (caps_rtp_video) {
+        g_object_set(pc->capsfilter_rtp_video, "caps", caps_rtp_video, NULL);
+        gst_caps_unref(caps_rtp_video);
+    }
 
     g_object_set(pc->parser, "config-interval", -1, NULL);
     g_object_set(pc->capsfilter, "caps", caps_h265, NULL);
@@ -704,10 +719,12 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         }
     }
 
-    gst_bin_add_many(GST_BIN(pc->pipeline),
-                     pc->appsrc_element, pc->queue0, pc->tee,
-                     pc->queue_video_in, pc->capsfilter_rtp_video, pc->jitterbuffer,
-                     pc->depay, pc->parser, pc->capsfilter,
+    gst_bin_add_many(GST_BIN(pc->pipeline), pc->appsrc_element, pc->queue0, NULL);
+    if (pc->ingress_mode == UV_INGRESS_UDP) {
+        gst_bin_add_many(GST_BIN(pc->pipeline), pc->tee, pc->queue_video_in,
+                         pc->capsfilter_rtp_video, pc->jitterbuffer, pc->depay, NULL);
+    }
+    gst_bin_add_many(GST_BIN(pc->pipeline), pc->parser, pc->capsfilter,
                      pc->decoder, pc->queue_postdec, NULL);
     if (pc->video_hw_convert) {
         gst_bin_add(GST_BIN(pc->pipeline), pc->video_hw_convert);
@@ -743,20 +760,17 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         return FALSE;
     }
 
-    if (!gst_element_link(pc->queue0, pc->tee)) {
-        g_set_error(error, g_quark_from_static_string("uv-viewer"), 14,
-                    "Failed to link ingress queue to tee");
-        return FALSE;
+    gboolean video_linked;
+    if (pc->ingress_mode == UV_INGRESS_SHM) {
+        video_linked = gst_element_link_many(pc->queue0, pc->parser, pc->capsfilter,
+                                             pc->decoder, pc->queue_postdec, NULL);
+    } else {
+        video_linked = gst_element_link_many(pc->queue0, pc->tee, pc->queue_video_in,
+                                             pc->capsfilter_rtp_video, pc->jitterbuffer,
+                                             pc->depay, pc->parser, pc->capsfilter,
+                                             pc->decoder, pc->queue_postdec, NULL);
     }
-
-    if (!gst_element_link(pc->tee, pc->queue_video_in)) {
-        g_set_error(error, g_quark_from_static_string("uv-viewer"), 14,
-                    "Failed to link tee to video queue");
-        return FALSE;
-    }
-
-    if (!gst_element_link_many(pc->queue_video_in, pc->capsfilter_rtp_video, pc->jitterbuffer,
-                               pc->depay, pc->parser, pc->capsfilter, pc->decoder, pc->queue_postdec, NULL)) {
+    if (!video_linked) {
         g_set_error(error, g_quark_from_static_string("uv-viewer"), 14,
                     "Failed to link video branch");
         return FALSE;
@@ -912,7 +926,6 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
         }
     }
 
-    relay_controller_set_appsrc(&viewer->relay, GST_APP_SRC(pc->appsrc_element));
     return TRUE;
 }
 
@@ -943,6 +956,7 @@ gboolean pipeline_controller_init(PipelineController *pc, struct _UvViewer *view
     (void)error;
     g_return_val_if_fail(pc != NULL, FALSE);
     memset(pc, 0, sizeof(*pc));
+    pc->ingress_mode = UV_INGRESS_UDP;
     pc->viewer = viewer;
     pc->payload_type = viewer->config.payload_type;
     pc->clock_rate = viewer->config.clock_rate;
@@ -987,7 +1001,10 @@ void pipeline_controller_deinit(PipelineController *pc) {
     if (!pc) return;
     pipeline_controller_stop(pc);
     if (pc->bus_watch_id) {
-        g_source_remove(pc->bus_watch_id);
+        GSource *source = pc->loop_context
+                        ? g_main_context_find_source_by_id(pc->loop_context, pc->bus_watch_id)
+                        : NULL;
+        if (source) g_source_destroy(source);
         pc->bus_watch_id = 0;
     }
     remove_audio_probe(pc);
@@ -1137,6 +1154,7 @@ gboolean pipeline_controller_start(PipelineController *pc, GError **error) {
 void pipeline_controller_stop(PipelineController *pc) {
     if (!pc) return;
     relay_controller_set_push_enabled(&pc->viewer->relay, FALSE);
+    shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, FALSE);
     if (pc->loop) g_main_loop_quit(pc->loop);
     if (pc->loop_thread) {
         g_thread_join(pc->loop_thread);
@@ -1282,4 +1300,12 @@ gboolean pipeline_controller_update(PipelineController *pc, const UvPipelineOver
 
 GstElement *pipeline_controller_get_sink(PipelineController *pc) {
     return pc ? pc->sink : NULL;
+}
+
+UvIngressMode pipeline_controller_ingress_mode(PipelineController *pc) {
+    return pc ? pc->ingress_mode : UV_INGRESS_UDP;
+}
+
+void pipeline_controller_set_ingress_mode(PipelineController *pc, UvIngressMode mode) {
+    if (pc) pc->ingress_mode = mode;
 }

--- a/src/relay_controller.c
+++ b/src/relay_controller.c
@@ -292,7 +292,8 @@ gboolean relay_controller_get_selected_address(RelayController *rc, char *out, s
     gboolean found = FALSE;
     g_mutex_lock(&rc->lock);
     int idx = rc->selected_index;
-    if (idx >= 0 && idx < (int)rc->sources_count && rc->sources[idx].in_use) {
+    if (idx >= 0 && idx < (int)rc->sources_count && rc->sources[idx].in_use &&
+        rc->sources[idx].kind == UV_SOURCE_UDP) {
         addr_to_str(&rc->sources[idx].addr, out, outlen);
         found = TRUE;
     }
@@ -386,6 +387,7 @@ static bool relay_add_or_find(RelayController *rc, const struct sockaddr_in *fro
     for (guint i = 0; i < rc->sources_count; i++) {
         UvRelaySource *slot = &rc->sources[i];
         if (!slot->in_use) continue;
+        if (slot->kind != UV_SOURCE_UDP) continue;
         if (slot->addr.sin_family == from->sin_family &&
             slot->addr.sin_addr.s_addr == from->sin_addr.s_addr) {
             if (slot->addr.sin_port != from->sin_port) {
@@ -400,6 +402,7 @@ static bool relay_add_or_find(RelayController *rc, const struct sockaddr_in *fro
     if (rc->sources_count >= UV_RELAY_MAX_SOURCES) return FALSE;
     UvRelaySource *ns = &rc->sources[rc->sources_count];
     memset(ns, 0, sizeof(*ns));
+    ns->kind = UV_SOURCE_UDP;
     ns->addr = *from;
     ns->addrlen = fromlen;
     ns->in_use = TRUE;
@@ -465,6 +468,8 @@ static void source_record_marker_frame(UvRelaySource *src, gint64 arrival_us) {
     }
 }
 
+static void hevc_count_nal_type(UvRelaySource *s, uint8_t nal_type, gint64 arrival_us);
+
 static double source_marker_window_fps(const UvRelaySource *src, gint64 now_us) {
     if (!src || src->frame_times_count < 2 || now_us <= 0) return 0.0;
 
@@ -493,23 +498,39 @@ static double source_marker_window_fps(const UvRelaySource *src, gint64 now_us) 
 void uv_internal_populate_source_stats(const UvRelaySource *src, int clock_rate,
                                        gint64 now_us, UvSourceStats *out) {
     if (!src || !out) return;
-    addr_to_str(&src->addr, out->address, sizeof(out->address));
+    out->kind = src->kind;
+    if (src->kind == UV_SOURCE_SHM) {
+        g_strlcpy(out->address, src->label, sizeof(out->address));
+    } else {
+        addr_to_str(&src->addr, out->address, sizeof(out->address));
+    }
     out->rx_packets = src->rx_packets;
     out->rx_bytes = src->rx_bytes;
     out->forwarded_packets = src->forwarded_packets;
     out->forwarded_bytes = src->forwarded_bytes;
-    out->rtp_unique_packets = src->rtp_unique_packets;
+    out->rtp_unique_packets = src->kind == UV_SOURCE_SHM ? UINT64_MAX : src->rtp_unique_packets;
+    if (src->kind == UV_SOURCE_SHM) {
+        out->rtp_expected_packets = UINT64_MAX;
+        out->rtp_lost_packets = UINT64_MAX;
+        out->rtp_duplicate_packets = UINT64_MAX;
+        out->rtp_reordered_packets = UINT64_MAX;
+        out->rtp_ap_packets = UINT64_MAX;
+        out->rtp_fu_packets = UINT64_MAX;
+        out->rfc3550_jitter_ms = -1.0;
+    }
     if (src->rtp_initialized) {
         out->rtp_expected_packets = (uint64_t)(src->rtp_max_ext_seq - src->rtp_first_ext_seq + 1);
         if (out->rtp_expected_packets > out->rtp_unique_packets) {
             out->rtp_lost_packets = out->rtp_expected_packets - out->rtp_unique_packets;
         }
     }
-    out->rtp_duplicate_packets = src->rtp_duplicate_packets;
-    out->rtp_reordered_packets = src->rtp_reordered_packets;
+    if (src->kind != UV_SOURCE_SHM) {
+        out->rtp_duplicate_packets = src->rtp_duplicate_packets;
+        out->rtp_reordered_packets = src->rtp_reordered_packets;
+    }
     out->rtp_marker_frames = src->rtp_marker_frames;
     out->rtp_marker_fps = source_marker_window_fps(src, now_us);
-    if (src->jitter_value > 0.0) {
+    if (src->kind != UV_SOURCE_SHM && src->jitter_value > 0.0) {
         out->rfc3550_jitter_ms = (src->jitter_value * 1000.0) / (double)MAX(clock_rate, 1);
     }
     if (src->last_seen_us > 0) {
@@ -517,6 +538,84 @@ void uv_internal_populate_source_stats(const UvRelaySource *src, int clock_rate,
     } else {
         out->seconds_since_last_seen = -1.0;
     }
+}
+
+int relay_controller_register_shm(RelayController *rc, const char *label) {
+    int index = -1;
+    UvRelaySource snapshot = {0};
+    gboolean added = FALSE;
+    g_mutex_lock(&rc->lock);
+    for (guint i = 0; i < rc->sources_count; i++) {
+        if (rc->sources[i].kind == UV_SOURCE_SHM &&
+            g_strcmp0(rc->sources[i].label, label) == 0) {
+            index = (int)i;
+            break;
+        }
+    }
+    if (index < 0 && rc->sources_count < UV_RELAY_MAX_SOURCES) {
+        index = (int)rc->sources_count++;
+        UvRelaySource *src = &rc->sources[index];
+        memset(src, 0, sizeof(*src));
+        src->kind = UV_SOURCE_SHM;
+        src->in_use = TRUE;
+        g_strlcpy(src->label, label, sizeof(src->label));
+        relay_source_clear_stats(src, TRUE);
+        added = TRUE;
+    }
+    if (index >= 0) snapshot = rc->sources[index];
+    g_mutex_unlock(&rc->lock);
+    if (added) uv_internal_emit_event(rc->viewer, UV_VIEWER_EVENT_SOURCE_ADDED,
+                                      index, &snapshot, NULL);
+    return index;
+}
+
+static void hevc_parse_annex_b_stats(UvRelaySource *src, const uint8_t *au,
+                                     size_t len, gint64 now_us) {
+    size_t i = 0;
+    while (i + 4 <= len) {
+        size_t start = SIZE_MAX;
+        for (; i + 3 <= len; i++) {
+            if (au[i] == 0 && au[i + 1] == 0 && au[i + 2] == 1) {
+                start = i + 3;
+                break;
+            }
+            if (i + 4 <= len && au[i] == 0 && au[i + 1] == 0 &&
+                au[i + 2] == 0 && au[i + 3] == 1) {
+                start = i + 4;
+                break;
+            }
+        }
+        if (start == SIZE_MAX || start >= len) break;
+        hevc_count_nal_type(src, (uint8_t)((au[start] >> 1) & 0x3f), now_us);
+        i = start + 1;
+    }
+}
+
+void relay_controller_shm_frame(RelayController *rc, int idx, const uint8_t *au,
+                                size_t len, const VencFrameMeta *meta) {
+    (void)meta;
+    gint64 now_us = g_get_monotonic_time();
+    g_mutex_lock(&rc->lock);
+    if (idx >= 0 && (guint)idx < rc->sources_count &&
+        rc->sources[idx].kind == UV_SOURCE_SHM) {
+        UvRelaySource *src = &rc->sources[idx];
+        src->rx_packets++;
+        src->rx_bytes += len;
+        src->last_seen_us = now_us;
+        source_record_marker_frame(src, now_us);
+        hevc_parse_annex_b_stats(src, au, len, now_us);
+    }
+    g_mutex_unlock(&rc->lock);
+}
+
+UvSourceKind relay_controller_source_kind(RelayController *rc, int index) {
+    UvSourceKind kind = UV_SOURCE_UDP;
+    g_mutex_lock(&rc->lock);
+    if (index >= 0 && (guint)index < rc->sources_count && rc->sources[index].in_use) {
+        kind = rc->sources[index].kind;
+    }
+    g_mutex_unlock(&rc->lock);
+    return kind;
 }
 
 /* Push a completed frame into the per-source cadence ring (oldest overwritten). */
@@ -1531,8 +1630,10 @@ void relay_controller_snapshot(RelayController *rc, UvViewerStats *stats, int cl
         s.hevc_aud_count       = src->hevc_aud_count;
         s.hevc_sei_count       = src->hevc_sei_count;
         s.hevc_other_nal_count = src->hevc_other_nal_count;
-        s.rtp_ap_packets       = src->rtp_ap_packets;
-        s.rtp_fu_packets       = src->rtp_fu_packets;
+        if (src->kind != UV_SOURCE_SHM) {
+            s.rtp_ap_packets = src->rtp_ap_packets;
+            s.rtp_fu_packets = src->rtp_fu_packets;
+        }
         if (src->last_keyframe_us > 0) {
             s.seconds_since_keyframe = (double)(now_us - src->last_keyframe_us) / 1e6;
         } else {

--- a/src/shm_ingress.c
+++ b/src/shm_ingress.c
@@ -1,0 +1,245 @@
+#define _GNU_SOURCE
+#include "uv_internal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+static inline uint32_t load_u32(const void *base, size_t off) {
+    return __atomic_load_n((const uint32_t *)((const uint8_t *)base + off), __ATOMIC_ACQUIRE);
+}
+
+static inline uint64_t load_u64(const void *base, size_t off) {
+    return __atomic_load_n((const uint64_t *)((const uint8_t *)base + off), __ATOMIC_ACQUIRE);
+}
+
+static inline void store_u32(void *base, size_t off, uint32_t value, int order) {
+    __atomic_store_n((uint32_t *)((uint8_t *)base + off), value, order);
+}
+
+static inline void store_u64(void *base, size_t off, uint64_t value) {
+    __atomic_store_n((uint64_t *)((uint8_t *)base + off), value, __ATOMIC_RELEASE);
+}
+
+static void shm_detach_locked(ShmIngress *si) {
+    if (si->base) munmap(si->base, si->map_size);
+    si->base = NULL;
+    si->map_size = 0;
+    si->attached = FALSE;
+}
+
+static gboolean shm_try_attach(ShmIngress *si) {
+    int fd = shm_open(si->name, O_RDWR, 0);
+    if (fd < 0) return FALSE;
+    struct stat st;
+    if (fstat(fd, &st) != 0 || st.st_size < (off_t)VFRM_HEADER_SIZE) {
+        close(fd);
+        return FALSE;
+    }
+    void *base = mmap(NULL, (size_t)st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (base == MAP_FAILED) return FALSE;
+
+    uint32_t slots = load_u32(base, VFRM_OFF_SLOT_COUNT);
+    uint32_t data_size = load_u32(base, VFRM_OFF_SLOT_DATA_SIZE);
+    size_t stride = vfrm_align8(sizeof(uint32_t) + (size_t)data_size);
+    uint64_t expected = VFRM_HEADER_SIZE + (uint64_t)slots * stride;
+    gboolean valid = load_u32(base, VFRM_OFF_INIT_COMPLETE) == 1 &&
+                     load_u32(base, VFRM_OFF_MAGIC) == VFRM_MAGIC &&
+                     load_u32(base, VFRM_OFF_VERSION) == VFRM_VERSION &&
+                     slots > 0 && (slots & (slots - 1u)) == 0 && data_size > 0 &&
+                     expected == (uint64_t)st.st_size &&
+                     load_u32(base, VFRM_OFF_TOTAL_SIZE) == (uint32_t)st.st_size;
+    if (!valid) {
+        munmap(base, (size_t)st.st_size);
+        return FALSE;
+    }
+
+    g_mutex_lock(&si->lock);
+    shm_detach_locked(si);
+    si->base = base;
+    si->map_size = (size_t)st.st_size;
+    si->slot_count = slots;
+    si->slot_data_size = data_size;
+    si->stride = stride;
+    si->st_dev = st.st_dev;
+    si->st_ino = st.st_ino;
+    si->attached = TRUE;
+    g_mutex_unlock(&si->lock);
+
+    if (si->source_index < 0) {
+        char label[UV_VIEWER_ADDR_MAX];
+        g_snprintf(label, sizeof(label), "shm:%s", si->name);
+        si->source_index = relay_controller_register_shm(si->registry, label);
+    }
+    uv_log_info("SHM ingress attached to %s (%u slots, %u bytes each)",
+                si->name, slots, data_size);
+    return TRUE;
+}
+
+static gboolean backing_object_current(ShmIngress *si) {
+    int fd = shm_open(si->name, O_RDWR, 0);
+    if (fd < 0) return FALSE;
+    struct stat st;
+    gboolean current = fstat(fd, &st) == 0 && st.st_dev == si->st_dev &&
+                       st.st_ino == si->st_ino &&
+                       load_u32(si->base, VFRM_OFF_INIT_COMPLETE) == 1;
+    close(fd);
+    return current;
+}
+
+static void push_frame(ShmIngress *si, const uint8_t *data, size_t len,
+                       const VencFrameMeta *meta) {
+    if (len <= sizeof(*meta) || meta->codec != UV_FRAME_CODEC_H265 || meta->reserved != 0) {
+        g_mutex_lock(&si->lock);
+        si->bad_slots++;
+        g_mutex_unlock(&si->lock);
+        return;
+    }
+    const uint8_t *au = data + sizeof(*meta);
+    size_t au_len = len - sizeof(*meta);
+    relay_controller_shm_frame(si->registry, si->source_index, au, au_len, meta);
+
+    g_mutex_lock(&si->lock);
+    si->frames++;
+    si->bytes += au_len;
+    GstAppSrc *appsrc = si->push_enabled && si->appsrc
+                      ? GST_APP_SRC(gst_object_ref(si->appsrc)) : NULL;
+    g_mutex_unlock(&si->lock);
+    if (!appsrc) return;
+    GstBuffer *buffer = gst_buffer_new_allocate(NULL, au_len, NULL);
+    if (buffer) {
+        gst_buffer_fill(buffer, 0, au, au_len);
+        GstFlowReturn flow = gst_app_src_push_buffer(appsrc, buffer);
+        if (flow != GST_FLOW_OK && flow != GST_FLOW_FLUSHING) {
+            uv_log_warn("SHM appsrc push returned %s", gst_flow_get_name(flow));
+        }
+    }
+    gst_object_unref(appsrc);
+}
+
+static gpointer shm_thread_run(gpointer data) {
+    ShmIngress *si = data;
+    gint64 last_frame_us = g_get_monotonic_time();
+    while (!si->stop) {
+        if (!si->attached) {
+            if (!shm_try_attach(si)) g_usleep(500000);
+            last_frame_us = g_get_monotonic_time();
+            continue;
+        }
+        uint64_t read_idx = load_u64(si->base, VFRM_OFF_READ_IDX);
+        uint64_t write_idx = load_u64(si->base, VFRM_OFF_WRITE_IDX);
+        gboolean drained = FALSE;
+        while (!si->stop && read_idx != write_idx) {
+            uint8_t *slot = (uint8_t *)si->base + VFRM_HEADER_SIZE +
+                            (read_idx & (si->slot_count - 1u)) * si->stride;
+            uint32_t length;
+            memcpy(&length, slot, sizeof(length));
+            if (length > si->slot_data_size || length < sizeof(VencFrameMeta)) {
+                g_mutex_lock(&si->lock);
+                si->bad_slots++;
+                g_mutex_unlock(&si->lock);
+            } else {
+                VencFrameMeta meta;
+                memcpy(&meta, slot + sizeof(length), sizeof(meta));
+                push_frame(si, slot + sizeof(length), length, &meta);
+            }
+            read_idx++;
+            store_u64(si->base, VFRM_OFF_READ_IDX, read_idx);
+            write_idx = load_u64(si->base, VFRM_OFF_WRITE_IDX);
+            drained = TRUE;
+        }
+        if (drained) {
+            last_frame_us = g_get_monotonic_time();
+            continue;
+        }
+        store_u32(si->base, VFRM_OFF_CONSUMER_WAITING, 1, __ATOMIC_SEQ_CST);
+        uint32_t seq = load_u32(si->base, VFRM_OFF_FUTEX_SEQ);
+        struct timespec timeout = { .tv_sec = 0, .tv_nsec = 100000000 };
+        syscall(SYS_futex, (uint32_t *)((uint8_t *)si->base + VFRM_OFF_FUTEX_SEQ),
+                FUTEX_WAIT, seq, &timeout, NULL, 0);
+        store_u32(si->base, VFRM_OFF_CONSUMER_WAITING, 0, __ATOMIC_SEQ_CST);
+        if (g_get_monotonic_time() - last_frame_us >= 500000 && !backing_object_current(si)) {
+            g_mutex_lock(&si->lock);
+            shm_detach_locked(si);
+            si->reattaches++;
+            g_mutex_unlock(&si->lock);
+            uv_log_warn("SHM ingress %s detached; waiting for producer", si->name);
+        }
+    }
+    return NULL;
+}
+
+gboolean shm_ingress_init(ShmIngress *si, struct _UvViewer *viewer,
+                          RelayController *registry) {
+    memset(si, 0, sizeof(*si));
+    g_mutex_init(&si->lock);
+    si->enabled = viewer->config.shm_enabled;
+    const char *name = viewer->config.shm_name[0] ? viewer->config.shm_name : "venc_frame_out";
+    g_snprintf(si->name, sizeof(si->name), "%s%s", name[0] == '/' ? "" : "/", name);
+    si->registry = registry;
+    si->source_index = -1;
+    return TRUE;
+}
+
+void shm_ingress_deinit(ShmIngress *si) {
+    if (!si) return;
+    shm_ingress_stop(si);
+    shm_ingress_set_appsrc(si, NULL);
+    g_mutex_lock(&si->lock);
+    shm_detach_locked(si);
+    g_mutex_unlock(&si->lock);
+    g_mutex_clear(&si->lock);
+}
+
+gboolean shm_ingress_start(ShmIngress *si) {
+    if (!si || !si->enabled || si->thread) return TRUE;
+    si->stop = FALSE;
+    si->thread = g_thread_new("uv-shm-ingress", shm_thread_run, si);
+    return si->thread != NULL;
+}
+
+void shm_ingress_stop(ShmIngress *si) {
+    if (!si) return;
+    si->stop = TRUE;
+    if (si->thread) {
+        g_thread_join(si->thread);
+        si->thread = NULL;
+    }
+}
+
+void shm_ingress_set_appsrc(ShmIngress *si, GstAppSrc *appsrc) {
+    g_mutex_lock(&si->lock);
+    if (appsrc) gst_object_ref(appsrc);
+    GstAppSrc *old = si->appsrc;
+    si->appsrc = appsrc;
+    g_mutex_unlock(&si->lock);
+    if (old) gst_object_unref(old);
+}
+
+void shm_ingress_set_push_enabled(ShmIngress *si, gboolean enabled) {
+    g_mutex_lock(&si->lock);
+    si->push_enabled = enabled;
+    g_mutex_unlock(&si->lock);
+}
+
+void shm_ingress_snapshot(ShmIngress *si, UvSourceStats *stats) {
+    g_mutex_lock(&si->lock);
+    stats->shm_attached = si->attached;
+    stats->shm_oversize_drops = si->oversize_drops;
+    stats->shm_bad_slots = si->bad_slots;
+    stats->shm_reattaches = si->reattaches;
+    if (si->attached) {
+        uint64_t used = load_u64(si->base, VFRM_OFF_WRITE_IDX) -
+                        load_u64(si->base, VFRM_OFF_READ_IDX);
+        if (used > si->slot_count) used = si->slot_count;
+        stats->shm_fill_pct = 100.0 * (double)used / (double)si->slot_count;
+    }
+    g_mutex_unlock(&si->lock);
+}

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -2,6 +2,7 @@
 #define UV_INTERNAL_H
 
 #include "uv_viewer.h"
+#include "frame_shm_format.h"
 
 #include <gst/app/gstappsrc.h>
 #include <arpa/inet.h>
@@ -26,6 +27,8 @@ G_BEGIN_DECLS
 struct UvFrameBlockState;
 
 typedef struct {
+    UvSourceKind kind;
+    char label[UV_VIEWER_ADDR_MAX];
     struct sockaddr_in addr;
     socklen_t addrlen;
     bool in_use;
@@ -180,6 +183,37 @@ typedef struct {
     struct _UvViewer *viewer;
 } RelayController;
 
+typedef struct {
+    char name[UV_SHM_NAME_MAX];
+    gboolean enabled;
+    void *base;
+    size_t map_size;
+    uint32_t slot_count;
+    uint32_t slot_data_size;
+    size_t stride;
+    dev_t st_dev;
+    ino_t st_ino;
+    gboolean attached;
+    GThread *thread;
+    volatile gboolean stop;
+    volatile gboolean push_enabled;
+    GMutex lock;
+    GstAppSrc *appsrc;
+    RelayController *registry;
+    int source_index;
+    uint64_t frames;
+    uint64_t bytes;
+    uint64_t full_drops_seen;
+    uint64_t oversize_drops;
+    uint64_t bad_slots;
+    uint64_t reattaches;
+} ShmIngress;
+
+typedef enum {
+    UV_INGRESS_UDP = 0,
+    UV_INGRESS_SHM
+} UvIngressMode;
+
 #define UV_SIDECAR_AVG_WINDOW 64u
 
 typedef struct {
@@ -266,6 +300,7 @@ typedef struct {
 } QoSDatabase;
 
 typedef struct {
+    UvIngressMode ingress_mode;
     int payload_type;
     int clock_rate;
     gboolean sync_to_clock;
@@ -340,6 +375,7 @@ struct _UvViewer {
     DecoderStats decoder;
     QoSDatabase qos;
     SidecarController sidecar;
+    ShmIngress shm_ingress;
 
     GMutex state_lock;
     gboolean started;
@@ -371,6 +407,10 @@ void     relay_controller_snapshot(RelayController *rc, UvViewerStats *stats, in
 void     relay_controller_set_appsrc(RelayController *rc, GstAppSrc *appsrc);
 void     relay_controller_set_audio_appsrc(RelayController *rc, GstAppSrc *audio_appsrc);
 void     relay_controller_set_push_enabled(RelayController *rc, gboolean enabled);
+int      relay_controller_register_shm(RelayController *rc, const char *label);
+void     relay_controller_shm_frame(RelayController *rc, int idx, const uint8_t *au,
+                                    size_t len, const VencFrameMeta *meta);
+UvSourceKind relay_controller_source_kind(RelayController *rc, int index);
 void     relay_controller_frame_block_configure(RelayController *rc, gboolean enabled, gboolean snapshot_mode);
 void     relay_controller_frame_block_pause(RelayController *rc, gboolean paused);
 void     relay_controller_frame_block_reset(RelayController *rc);
@@ -422,6 +462,17 @@ GstAppSrc *pipeline_controller_get_audio_appsrc(PipelineController *pc);
 void     pipeline_controller_snapshot(PipelineController *pc, UvViewerStats *stats);
 gboolean pipeline_controller_update(PipelineController *pc, const UvPipelineOverrides *overrides, GError **error);
 GstElement *pipeline_controller_get_sink(PipelineController *pc);
+UvIngressMode pipeline_controller_ingress_mode(PipelineController *pc);
+void pipeline_controller_set_ingress_mode(PipelineController *pc, UvIngressMode mode);
+
+gboolean shm_ingress_init(ShmIngress *si, struct _UvViewer *viewer,
+                          RelayController *registry);
+void shm_ingress_deinit(ShmIngress *si);
+gboolean shm_ingress_start(ShmIngress *si);
+void shm_ingress_stop(ShmIngress *si);
+void shm_ingress_set_appsrc(ShmIngress *si, GstAppSrc *appsrc);
+void shm_ingress_set_push_enabled(ShmIngress *si, gboolean enabled);
+void shm_ingress_snapshot(ShmIngress *si, UvSourceStats *stats);
 
 GstElement *uv_internal_viewer_get_sink(struct _UvViewer *viewer);
 

--- a/src/viewer_core.c
+++ b/src/viewer_core.c
@@ -42,6 +42,8 @@ void uv_viewer_config_init(UvViewerConfig *cfg) {
     cfg->restream_enabled = FALSE;
     cfg->restream_address[0] = '\0';
     cfg->restream_port = 5600;
+    cfg->shm_enabled = FALSE;
+    g_strlcpy(cfg->shm_name, "venc_frame_out", sizeof(cfg->shm_name));
 }
 
 UvViewer *uv_viewer_new(const UvViewerConfig *cfg) {
@@ -62,6 +64,7 @@ UvViewer *uv_viewer_new(const UvViewerConfig *cfg) {
         return NULL;
     }
     sidecar_controller_init(&viewer->sidecar, viewer);
+    shm_ingress_init(&viewer->shm_ingress, viewer, &viewer->relay);
     return viewer;
 }
 
@@ -69,6 +72,7 @@ void uv_viewer_free(UvViewer *viewer) {
     if (!viewer) return;
     uv_viewer_stop(viewer);
     sidecar_controller_deinit(&viewer->sidecar);
+    shm_ingress_deinit(&viewer->shm_ingress);
     relay_controller_deinit(&viewer->relay);
     pipeline_controller_deinit(&viewer->pipeline);
     uv_internal_qos_db_clear(&viewer->qos);
@@ -92,7 +96,14 @@ bool uv_viewer_start(UvViewer *viewer, GError **error) {
     g_mutex_unlock(&viewer->state_lock);
 
     if (!pipeline_controller_start(&viewer->pipeline, error)) return FALSE;
-    relay_controller_set_appsrc(&viewer->relay, pipeline_controller_get_appsrc(&viewer->pipeline));
+    GstAppSrc *appsrc = pipeline_controller_get_appsrc(&viewer->pipeline);
+    if (pipeline_controller_ingress_mode(&viewer->pipeline) == UV_INGRESS_SHM) {
+        relay_controller_set_appsrc(&viewer->relay, NULL);
+        shm_ingress_set_appsrc(&viewer->shm_ingress, appsrc);
+    } else {
+        relay_controller_set_appsrc(&viewer->relay, appsrc);
+        shm_ingress_set_appsrc(&viewer->shm_ingress, NULL);
+    }
     relay_controller_set_audio_appsrc(&viewer->relay,
                                       pipeline_controller_get_audio_appsrc(&viewer->pipeline));
     if (!relay_controller_start(&viewer->relay)) {
@@ -103,6 +114,9 @@ bool uv_viewer_start(UvViewer *viewer, GError **error) {
     }
 
     sidecar_controller_start(&viewer->sidecar);
+    if (!shm_ingress_start(&viewer->shm_ingress)) {
+        uv_log_warn("Failed to start SHM ingress thread");
+    }
 
     /* Honour a restream destination carried in the config (e.g. after an
      * Apply-Settings restart that rebuilt the viewer). */
@@ -129,6 +143,8 @@ void uv_viewer_stop(UvViewer *viewer) {
     g_mutex_unlock(&viewer->state_lock);
 
     sidecar_controller_stop(&viewer->sidecar);
+    shm_ingress_stop(&viewer->shm_ingress);
+    shm_ingress_set_appsrc(&viewer->shm_ingress, NULL);
     relay_controller_stop(&viewer->relay);
     pipeline_controller_stop(&viewer->pipeline);
 }
@@ -150,9 +166,11 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
      * guarantees no concurrent access for the rest of the rebuild. */
     relay_controller_stop(&viewer->relay);
     relay_controller_set_appsrc(&viewer->relay, NULL);
+    shm_ingress_set_appsrc(&viewer->shm_ingress, NULL);
     relay_controller_set_audio_appsrc(&viewer->relay, NULL);
 
     /* Tear the pipeline all the way down so build_pipeline runs again. */
+    UvIngressMode ingress_mode = pipeline_controller_ingress_mode(&viewer->pipeline);
     pipeline_controller_deinit(&viewer->pipeline);
 
     /* Reset decoder + QoS stats so they reflect the new element instances,
@@ -169,6 +187,7 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
         g_mutex_unlock(&viewer->state_lock);
         return FALSE;
     }
+    pipeline_controller_set_ingress_mode(&viewer->pipeline, ingress_mode);
 
     if (!pipeline_controller_start(&viewer->pipeline, error)) {
         relay_controller_start(&viewer->relay);
@@ -178,7 +197,14 @@ bool uv_viewer_restart_pipeline(UvViewer *viewer, GError **error) {
         return FALSE;
     }
 
-    relay_controller_set_appsrc(&viewer->relay, pipeline_controller_get_appsrc(&viewer->pipeline));
+    GstAppSrc *appsrc = pipeline_controller_get_appsrc(&viewer->pipeline);
+    if (ingress_mode == UV_INGRESS_SHM) {
+        relay_controller_set_appsrc(&viewer->relay, NULL);
+        shm_ingress_set_appsrc(&viewer->shm_ingress, appsrc);
+    } else {
+        relay_controller_set_appsrc(&viewer->relay, appsrc);
+        shm_ingress_set_appsrc(&viewer->shm_ingress, NULL);
+    }
     relay_controller_set_audio_appsrc(&viewer->relay,
                                       pipeline_controller_get_audio_appsrc(&viewer->pipeline));
     if (!relay_controller_start(&viewer->relay)) {
@@ -203,12 +229,41 @@ void uv_viewer_set_event_callback(UvViewer *viewer, UvViewerEventCallback cb, gp
 
 bool uv_viewer_select_source(UvViewer *viewer, int index, GError **error) {
     if (!viewer) return FALSE;
+    UvSourceKind kind = relay_controller_source_kind(&viewer->relay, index);
+    UvIngressMode want = kind == UV_SOURCE_SHM ? UV_INGRESS_SHM : UV_INGRESS_UDP;
+    if (want != pipeline_controller_ingress_mode(&viewer->pipeline)) {
+        UvIngressMode previous = pipeline_controller_ingress_mode(&viewer->pipeline);
+        pipeline_controller_set_ingress_mode(&viewer->pipeline, want);
+        if (!uv_viewer_restart_pipeline(viewer, error)) {
+            pipeline_controller_set_ingress_mode(&viewer->pipeline, previous);
+            return FALSE;
+        }
+    }
     return relay_controller_select(&viewer->relay, index, error);
 }
 
 bool uv_viewer_select_next_source(UvViewer *viewer, GError **error) {
     if (!viewer) return FALSE;
-    return relay_controller_select_next(&viewer->relay, error);
+    int next = -1;
+    g_mutex_lock(&viewer->relay.lock);
+    if (viewer->relay.sources_count > 0) {
+        int current = viewer->relay.selected_index;
+        for (guint step = 1; step <= viewer->relay.sources_count; step++) {
+            guint candidate = (guint)(current < 0 ? (int)step - 1 : current + (int)step) %
+                              viewer->relay.sources_count;
+            if (viewer->relay.sources[candidate].in_use) {
+                next = (int)candidate;
+                break;
+            }
+        }
+    }
+    g_mutex_unlock(&viewer->relay.lock);
+    if (next < 0) {
+        g_set_error(error, g_quark_from_static_string("uv-viewer"), 2,
+                    "No sources available");
+        return FALSE;
+    }
+    return uv_viewer_select_source(viewer, next, error);
 }
 
 int uv_viewer_get_selected_source(const UvViewer *viewer) {
@@ -424,6 +479,10 @@ bool uv_viewer_get_stats(UvViewer *viewer, UvViewerStats *stats) {
     g_array_set_size(stats->sources, 0);
     g_array_set_size(stats->qos_entries, 0);
     relay_controller_snapshot(&viewer->relay, stats, viewer->config.clock_rate);
+    for (guint i = 0; i < stats->sources->len; i++) {
+        UvSourceStats *source = &g_array_index(stats->sources, UvSourceStats, i);
+        if (source->kind == UV_SOURCE_SHM) shm_ingress_snapshot(&viewer->shm_ingress, source);
+    }
     pipeline_controller_snapshot(&viewer->pipeline, stats);
     uv_internal_qos_db_snapshot(&viewer->qos, stats);
 


### PR DESCRIPTION
## Summary

- add the versioned shared-memory frame-ring ABI and an ingress worker with validation, futex wakeups, reattach handling, and H.265 metadata checks
- support switching the playback pipeline between RTP/UDP and direct shared-memory Annex-B input
- expose shared-memory configuration, health, and source statistics through the public API, CLI, and GTK settings/monitor views

## Impact

`radeon-vrx` can consume the producer shared-memory ring directly while retaining its existing RTP ingress path and runtime source selection.

## Validation

- `make clean && make`
- `git diff --check`
- standalone ABI header compilation with `-Werror`
- integration harness wrote a valid 30-frame H.265 stream into the VFRM ring and observed attachment, four frames pushed, source selection, pipeline switching, and decoder output (`attach=1 frames=4 decoder=120 kind=1`)
