### PR TITLE
Fix SHM ingress init on dropdown select, restart, and auto-connect

### DIFF
--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -3863,16 +3863,6 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
      * don't keep a dangling ref or signal handler on the old element. */
     detach_bound_sink(ctx);
 
-    /* Re-evaluate the ingress mode against the currently selected source
-     * before rebuilding.  A stale mode (e.g. UDP with an SHM source
-     * selected) would otherwise be silently preserved by restart. */
-    int sel = uv_viewer_get_selected_source(ctx->viewer);
-    if (sel >= 0) {
-        UvSourceKind kind = relay_controller_source_kind(&ctx->viewer->relay, sel);
-        UvIngressMode want = kind == UV_SOURCE_SHM ? UV_INGRESS_SHM : UV_INGRESS_UDP;
-        pipeline_controller_set_ingress_mode(&ctx->viewer->pipeline, want);
-    }
-
     GError *error = NULL;
     if (!uv_viewer_restart_pipeline(ctx->viewer, &error)) {
         uv_log_error("Pipeline restart failed: %s",
@@ -3880,10 +3870,17 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
         if (error) g_error_free(error);
     }
 
-    /* Re-select so SOURCE_SELECTED fires (triggers SHM recovery etc.). */
+    /* Re-select through the public API so ingress mode is re-evaluated
+     * and SOURCE_SELECTED fires (triggers SHM recovery etc.).
+     * uv_viewer_select_source handles rollback if a mode-change restart
+     * fails, and skips the select entirely on restart failure. */
+    int sel = uv_viewer_get_selected_source(ctx->viewer);
     if (sel >= 0) {
         GError *sel_error = NULL;
-        relay_controller_select(&ctx->viewer->relay, sel, &sel_error);
+        if (!uv_viewer_select_source(ctx->viewer, sel, &sel_error)) {
+            uv_log_warn("Source re-select after restart failed: %s",
+                        sel_error && sel_error->message ? sel_error->message : "unknown");
+        }
         if (sel_error) g_error_free(sel_error);
     }
 

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -3403,13 +3403,20 @@ static void refresh_stats(GuiContext *ctx) {
             if (ctx->pending_source_valid) {
                 desired = ctx->pending_source_index;
             }
+            guint current = gtk_drop_down_get_selected(ctx->source_dropdown);
             if (desired != GTK_INVALID_LIST_POSITION) {
-                guint current = gtk_drop_down_get_selected(ctx->source_dropdown);
                 if (current != desired) {
                     ctx->suppress_source_change = TRUE;
                     gtk_drop_down_set_selected(ctx->source_dropdown, desired);
                     ctx->suppress_source_change = FALSE;
                 }
+            } else if (current != GTK_INVALID_LIST_POSITION) {
+                /* No source is selected at the viewer level; clear the
+                 * dropdown so clicking a source actually fires the change
+                 * signal instead of appearing as a no-op. */
+                ctx->suppress_source_change = TRUE;
+                gtk_drop_down_set_selected(ctx->source_dropdown, GTK_INVALID_LIST_POSITION);
+                ctx->suppress_source_change = FALSE;
             }
         }
 
@@ -3856,11 +3863,28 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
      * don't keep a dangling ref or signal handler on the old element. */
     detach_bound_sink(ctx);
 
+    /* Re-evaluate the ingress mode against the currently selected source
+     * before rebuilding.  A stale mode (e.g. UDP with an SHM source
+     * selected) would otherwise be silently preserved by restart. */
+    int sel = uv_viewer_get_selected_source(ctx->viewer);
+    if (sel >= 0) {
+        UvSourceKind kind = relay_controller_source_kind(&ctx->viewer->relay, sel);
+        UvIngressMode want = kind == UV_SOURCE_SHM ? UV_INGRESS_SHM : UV_INGRESS_UDP;
+        pipeline_controller_set_ingress_mode(&ctx->viewer->pipeline, want);
+    }
+
     GError *error = NULL;
     if (!uv_viewer_restart_pipeline(ctx->viewer, &error)) {
         uv_log_error("Pipeline restart failed: %s",
                      error && error->message ? error->message : "unknown");
         if (error) g_error_free(error);
+    }
+
+    /* Re-select so SOURCE_SELECTED fires (triggers SHM recovery etc.). */
+    if (sel >= 0) {
+        GError *sel_error = NULL;
+        relay_controller_select(&ctx->viewer->relay, sel, &sel_error);
+        if (sel_error) g_error_free(sel_error);
     }
 
     /* Re-bind the paintable to the freshly built sink and update stats. */
@@ -4469,9 +4493,16 @@ static gboolean dispatch_ui_event(gpointer user_data) {
             g_snprintf(msg, sizeof(msg), "Discovered source [%d] %s",
                        event->source_index, event->address ? event->address : "");
             update_status(ctx, msg);
+            gboolean should_select = FALSE;
             if (event->source_index >= 0 && ctx->preferred_source_valid &&
                 event->source_kind == ctx->preferred_source_kind &&
                 g_strcmp0(event->address, ctx->preferred_source_address) == 0) {
+                should_select = TRUE;
+            } else if (event->source_index >= 0 && !ctx->active_source_valid &&
+                       uv_viewer_get_selected_source(ctx->viewer) < 0) {
+                should_select = TRUE;
+            }
+            if (should_select) {
                 ctx->pending_source_valid = TRUE;
                 ctx->pending_source_index = (guint)event->source_index;
                 detach_bound_sink(ctx);
@@ -4480,7 +4511,7 @@ static gboolean dispatch_ui_event(gpointer user_data) {
                                              &error)) {
                     update_status(ctx, error && error->message
                                            ? error->message
-                                           : "Failed to restore source selection");
+                                           : "Failed to select source");
                     ctx->pending_source_valid = FALSE;
                     ctx->pending_source_index = GTK_INVALID_LIST_POSITION;
                 }

--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -262,7 +262,7 @@ static void remove_audio_probe(PipelineController *pc) {
 static void on_need_data(GstAppSrc *src, guint length, gpointer user_data) {
     (void)src; (void)length;
     PipelineController *pc = (PipelineController *)user_data;
-    if (pc->ingress_mode == UV_INGRESS_SHM)
+    if (pipeline_controller_ingress_mode(pc) == UV_INGRESS_SHM)
         shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, TRUE);
     else
         relay_controller_set_push_enabled(&pc->viewer->relay, TRUE);
@@ -271,7 +271,7 @@ static void on_need_data(GstAppSrc *src, guint length, gpointer user_data) {
 static void on_enough_data(GstAppSrc *src, gpointer user_data) {
     (void)src;
     PipelineController *pc = (PipelineController *)user_data;
-    if (pc->ingress_mode == UV_INGRESS_SHM)
+    if (pipeline_controller_ingress_mode(pc) == UV_INGRESS_SHM)
         shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, FALSE);
     else
         relay_controller_set_push_enabled(&pc->viewer->relay, FALSE);
@@ -1303,9 +1303,10 @@ GstElement *pipeline_controller_get_sink(PipelineController *pc) {
 }
 
 UvIngressMode pipeline_controller_ingress_mode(PipelineController *pc) {
-    return pc ? pc->ingress_mode : UV_INGRESS_UDP;
+    return pc ? (UvIngressMode)__atomic_load_n(&pc->ingress_mode, __ATOMIC_ACQUIRE)
+              : UV_INGRESS_UDP;
 }
 
 void pipeline_controller_set_ingress_mode(PipelineController *pc, UvIngressMode mode) {
-    if (pc) pc->ingress_mode = mode;
+    if (pc) __atomic_store_n(&pc->ingress_mode, (int)mode, __ATOMIC_RELEASE);
 }

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -301,7 +301,7 @@ typedef struct {
 } QoSDatabase;
 
 typedef struct {
-    UvIngressMode ingress_mode;
+    int ingress_mode; /* UvIngressMode; int for __atomic ops */
     int payload_type;
     int clock_rate;
     gboolean sync_to_clock;


### PR DESCRIPTION
## Summary

- **Dropdown select**: Clear the GTK dropdown to `GTK_INVALID_LIST_POSITION` when no source is selected at the viewer level, so clicking an SHM source in the list actually fires `notify::selected` instead of appearing as a no-op.
- **Restart Pipeline button**: After the unconditional pipeline restart, re-select the current source through `uv_viewer_select_source` (the public API). This re-evaluates the ingress mode (UDP vs SHM), triggers `SOURCE_SELECTED` for SHM recovery, and properly rolls back on failure — replacing an earlier manual approach that called internal APIs without rollback.
- **Auto-connect**: Auto-select the first discovered source when nothing is currently selected (`!active_source_valid && selected_source < 0`), so SHM sources get selected on arrival just like UDP sources do via the relay thread.
- **Data race fix**: `on_need_data`/`on_enough_data` read `pc->ingress_mode` on GStreamer streaming threads while `pipeline_controller_set_ingress_mode` writes it from the GTK thread with no synchronization. Fixed with `__atomic` load/store (acquire/release) on the field, and routed the streaming callbacks through the accessor.

## Detail

SHM ingress previously only initialized when pressing "Next" because that path calls `uv_viewer_select_next_source` which bypasses the GTK dropdown entirely. The other three paths each had a different failure mode:

1. **Dropdown**: `refresh_stats` synced the dropdown to the viewer's selected index but never cleared it when no source was selected. If the dropdown showed index 0 and the user clicked index 0 (an SHM source), GTK treated it as no change and `notify::selected` never fired.

2. **Restart button**: `uv_viewer_restart_pipeline` preserves the current ingress mode, so restarting with a stale UDP mode while an SHM source was selected rebuilt a UDP pipeline. The fix calls `uv_viewer_select_source` after restart, which detects the mode mismatch and handles it (including rollback on failure).

3. **Auto-connect**: UDP sources auto-select in the relay thread (`relay_controller.c:1352`), but `relay_controller_register_shm` does not auto-select. The new `else if` in the `SOURCE_ADDED` handler fills this gap at the GUI level.

4. **Pre-existing data race**: `on_need_data` and `on_enough_data` in `pipeline_builder.c` branch on `pc->ingress_mode` to decide whether to toggle push-enable on SHM or relay. This field was written by `pipeline_controller_set_ingress_mode` (called from the GTK thread) with a bare assignment — no lock, no atomic. Between the mode write and pipeline teardown inside `uv_viewer_restart_pipeline`, a streaming callback could read the new mode and toggle the wrong subsystem's push flag.

## Test plan

- [ ] Start viewer with `--shm` and a running SHM producer — verify auto-connect selects the SHM source and video appears
- [ ] With SHM source active, click "Restart Pipeline" — verify video resumes (not a black screen from stale UDP mode)
- [ ] With SHM source listed but not selected, click it in the dropdown — verify it gets selected and video appears
- [ ] With SHM source active, click "Next" — verify it still works as before
- [ ] Simulate pipeline restart failure (e.g. bad sink) — verify no SOURCE_SELECTED fires and active_source_valid stays FALSE
- [ ] Under load, rapidly switch between UDP and SHM sources — verify no mis-routed push-enable (SHM frames to UDP path or vice versa)