### PR TITLE
SHM open/display: init-timing + data-race fixes with the IDR gate restored

### DIFF
--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -3863,16 +3863,6 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
      * don't keep a dangling ref or signal handler on the old element. */
     detach_bound_sink(ctx);
 
-    /* Re-evaluate the ingress mode against the currently selected source
-     * before rebuilding.  A stale mode (e.g. UDP with an SHM source
-     * selected) would otherwise be silently preserved by restart. */
-    int sel = uv_viewer_get_selected_source(ctx->viewer);
-    if (sel >= 0) {
-        UvSourceKind kind = relay_controller_source_kind(&ctx->viewer->relay, sel);
-        UvIngressMode want = kind == UV_SOURCE_SHM ? UV_INGRESS_SHM : UV_INGRESS_UDP;
-        pipeline_controller_set_ingress_mode(&ctx->viewer->pipeline, want);
-    }
-
     GError *error = NULL;
     if (!uv_viewer_restart_pipeline(ctx->viewer, &error)) {
         uv_log_error("Pipeline restart failed: %s",
@@ -3880,10 +3870,17 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
         if (error) g_error_free(error);
     }
 
-    /* Re-select so SOURCE_SELECTED fires (triggers SHM recovery etc.). */
+    /* Re-select through the public API so ingress mode is re-evaluated
+     * and SOURCE_SELECTED fires (triggers SHM recovery etc.).
+     * uv_viewer_select_source handles rollback if a mode-change restart
+     * fails, and skips the select entirely on restart failure. */
+    int sel = uv_viewer_get_selected_source(ctx->viewer);
     if (sel >= 0) {
         GError *sel_error = NULL;
-        relay_controller_select(&ctx->viewer->relay, sel, &sel_error);
+        if (!uv_viewer_select_source(ctx->viewer, sel, &sel_error)) {
+            uv_log_warn("Source re-select after restart failed: %s",
+                        sel_error && sel_error->message ? sel_error->message : "unknown");
+        }
         if (sel_error) g_error_free(sel_error);
     }
 

--- a/src/gui_shell.c
+++ b/src/gui_shell.c
@@ -3403,13 +3403,20 @@ static void refresh_stats(GuiContext *ctx) {
             if (ctx->pending_source_valid) {
                 desired = ctx->pending_source_index;
             }
+            guint current = gtk_drop_down_get_selected(ctx->source_dropdown);
             if (desired != GTK_INVALID_LIST_POSITION) {
-                guint current = gtk_drop_down_get_selected(ctx->source_dropdown);
                 if (current != desired) {
                     ctx->suppress_source_change = TRUE;
                     gtk_drop_down_set_selected(ctx->source_dropdown, desired);
                     ctx->suppress_source_change = FALSE;
                 }
+            } else if (current != GTK_INVALID_LIST_POSITION) {
+                /* No source is selected at the viewer level; clear the
+                 * dropdown so clicking a source actually fires the change
+                 * signal instead of appearing as a no-op. */
+                ctx->suppress_source_change = TRUE;
+                gtk_drop_down_set_selected(ctx->source_dropdown, GTK_INVALID_LIST_POSITION);
+                ctx->suppress_source_change = FALSE;
             }
         }
 
@@ -3856,11 +3863,28 @@ static void on_refresh_button_clicked(GtkButton *button, gpointer user_data) {
      * don't keep a dangling ref or signal handler on the old element. */
     detach_bound_sink(ctx);
 
+    /* Re-evaluate the ingress mode against the currently selected source
+     * before rebuilding.  A stale mode (e.g. UDP with an SHM source
+     * selected) would otherwise be silently preserved by restart. */
+    int sel = uv_viewer_get_selected_source(ctx->viewer);
+    if (sel >= 0) {
+        UvSourceKind kind = relay_controller_source_kind(&ctx->viewer->relay, sel);
+        UvIngressMode want = kind == UV_SOURCE_SHM ? UV_INGRESS_SHM : UV_INGRESS_UDP;
+        pipeline_controller_set_ingress_mode(&ctx->viewer->pipeline, want);
+    }
+
     GError *error = NULL;
     if (!uv_viewer_restart_pipeline(ctx->viewer, &error)) {
         uv_log_error("Pipeline restart failed: %s",
                      error && error->message ? error->message : "unknown");
         if (error) g_error_free(error);
+    }
+
+    /* Re-select so SOURCE_SELECTED fires (triggers SHM recovery etc.). */
+    if (sel >= 0) {
+        GError *sel_error = NULL;
+        relay_controller_select(&ctx->viewer->relay, sel, &sel_error);
+        if (sel_error) g_error_free(sel_error);
     }
 
     /* Re-bind the paintable to the freshly built sink and update stats. */
@@ -4469,9 +4493,16 @@ static gboolean dispatch_ui_event(gpointer user_data) {
             g_snprintf(msg, sizeof(msg), "Discovered source [%d] %s",
                        event->source_index, event->address ? event->address : "");
             update_status(ctx, msg);
+            gboolean should_select = FALSE;
             if (event->source_index >= 0 && ctx->preferred_source_valid &&
                 event->source_kind == ctx->preferred_source_kind &&
                 g_strcmp0(event->address, ctx->preferred_source_address) == 0) {
+                should_select = TRUE;
+            } else if (event->source_index >= 0 && !ctx->active_source_valid &&
+                       uv_viewer_get_selected_source(ctx->viewer) < 0) {
+                should_select = TRUE;
+            }
+            if (should_select) {
                 ctx->pending_source_valid = TRUE;
                 ctx->pending_source_index = (guint)event->source_index;
                 detach_bound_sink(ctx);
@@ -4480,7 +4511,7 @@ static gboolean dispatch_ui_event(gpointer user_data) {
                                              &error)) {
                     update_status(ctx, error && error->message
                                            ? error->message
-                                           : "Failed to restore source selection");
+                                           : "Failed to select source");
                     ctx->pending_source_valid = FALSE;
                     ctx->pending_source_index = GTK_INVALID_LIST_POSITION;
                 }

--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -262,7 +262,7 @@ static void remove_audio_probe(PipelineController *pc) {
 static void on_need_data(GstAppSrc *src, guint length, gpointer user_data) {
     (void)src; (void)length;
     PipelineController *pc = (PipelineController *)user_data;
-    if (pc->ingress_mode == UV_INGRESS_SHM)
+    if (pipeline_controller_ingress_mode(pc) == UV_INGRESS_SHM)
         shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, TRUE);
     else
         relay_controller_set_push_enabled(&pc->viewer->relay, TRUE);
@@ -271,7 +271,7 @@ static void on_need_data(GstAppSrc *src, guint length, gpointer user_data) {
 static void on_enough_data(GstAppSrc *src, gpointer user_data) {
     (void)src;
     PipelineController *pc = (PipelineController *)user_data;
-    if (pc->ingress_mode == UV_INGRESS_SHM)
+    if (pipeline_controller_ingress_mode(pc) == UV_INGRESS_SHM)
         shm_ingress_set_push_enabled(&pc->viewer->shm_ingress, FALSE);
     else
         relay_controller_set_push_enabled(&pc->viewer->relay, FALSE);
@@ -1303,9 +1303,10 @@ GstElement *pipeline_controller_get_sink(PipelineController *pc) {
 }
 
 UvIngressMode pipeline_controller_ingress_mode(PipelineController *pc) {
-    return pc ? pc->ingress_mode : UV_INGRESS_UDP;
+    return pc ? (UvIngressMode)__atomic_load_n(&pc->ingress_mode, __ATOMIC_ACQUIRE)
+              : UV_INGRESS_UDP;
 }
 
 void pipeline_controller_set_ingress_mode(PipelineController *pc, UvIngressMode mode) {
-    if (pc) pc->ingress_mode = mode;
+    if (pc) __atomic_store_n(&pc->ingress_mode, (int)mode, __ATOMIC_RELEASE);
 }

--- a/src/relay_controller.c
+++ b/src/relay_controller.c
@@ -608,6 +608,24 @@ void relay_controller_shm_frame(RelayController *rc, int idx, const uint8_t *au,
     g_mutex_unlock(&rc->lock);
 }
 
+void relay_controller_shm_reattached(RelayController *rc, int idx) {
+    UvRelaySource snapshot = {0};
+    gboolean selected = FALSE;
+    g_mutex_lock(&rc->lock);
+    if (idx >= 0 && (guint)idx < rc->sources_count &&
+        rc->sources[idx].kind == UV_SOURCE_SHM && rc->selected_index == idx) {
+        snapshot = rc->sources[idx];
+        selected = TRUE;
+    }
+    g_mutex_unlock(&rc->lock);
+    if (selected) {
+        /* Re-emit selection so the GUI requests a decoder-bootstrap IDR for
+         * the replacement producer before SHM ingress resumes pushing. */
+        uv_internal_emit_event(rc->viewer, UV_VIEWER_EVENT_SOURCE_SELECTED,
+                               idx, &snapshot, NULL);
+    }
+}
+
 UvSourceKind relay_controller_source_kind(RelayController *rc, int index) {
     UvSourceKind kind = UV_SOURCE_UDP;
     g_mutex_lock(&rc->lock);

--- a/src/shm_ingress.c
+++ b/src/shm_ingress.c
@@ -72,13 +72,23 @@ static gboolean shm_try_attach(ShmIngress *si) {
     si->st_dev = st.st_dev;
     si->st_ino = st.st_ino;
     si->attached = TRUE;
-    if (replacing_producer) si->stream_reset_pending = TRUE;
+    if (replacing_producer) {
+        /* A recreated ring is a brand-new encoded stream. Gate ingress on the
+         * next IDR and flush stale parser/decoder state when it arrives. */
+        si->waiting_for_idr = TRUE;
+        si->stream_reset_pending = TRUE;
+    }
     g_mutex_unlock(&si->lock);
 
     if (si->source_index < 0) {
         char label[UV_VIEWER_ADDR_MAX];
         g_snprintf(label, sizeof(label), "shm:%s", si->name);
         si->source_index = relay_controller_register_shm(si->registry, label);
+    } else if (replacing_producer) {
+        /* Re-emit selection so the GUI proactively requests a decoder-bootstrap
+         * IDR for the replacement producer before the gate has to wait for a
+         * natural keyframe. */
+        relay_controller_shm_reattached(si->registry, si->source_index);
     }
     uv_log_info("SHM ingress attached to %s (%u slots, %u bytes each)",
                 si->name, slots, data_size);
@@ -111,13 +121,19 @@ static void push_frame(ShmIngress *si, const uint8_t *data, size_t len,
     g_mutex_lock(&si->lock);
     si->frames++;
     si->bytes += au_len;
-    gboolean reset_stream = si->stream_reset_pending && si->appsrc;
-    GstAppSrc *appsrc = (si->push_enabled || reset_stream) && si->appsrc
+    gboolean is_idr = (meta->flags & UV_FRAME_FLAG_IDR) != 0;
+    /* A newly bound appsrc / recreated ring must start on a random-access unit.
+     * Drop deltas until the first IDR so we never seed a decoder mid-GOP. */
+    gboolean start_stream = si->waiting_for_idr && is_idr && si->appsrc;
+    gboolean reset_stream = start_stream && si->stream_reset_pending;
+    gboolean skip_delta = si->waiting_for_idr && !is_idr;
+    GstAppSrc *appsrc = !skip_delta && (si->push_enabled || start_stream) && si->appsrc
                       ? GST_APP_SRC(gst_object_ref(si->appsrc)) : NULL;
-    if (reset_stream) {
+    if (start_stream) {
+        si->waiting_for_idr = FALSE;
         si->stream_reset_pending = FALSE;
-        /* The flush empties appsrc, so force recovery out of a stale
-         * enough-data state. Its callbacks resume normal flow control. */
+        /* Force out of a stale enough-data state left by the previous stream so
+         * the random-access unit is accepted; callbacks resume flow control. */
         si->push_enabled = TRUE;
     }
     g_mutex_unlock(&si->lock);
@@ -135,7 +151,7 @@ static void push_frame(ShmIngress *si, const uint8_t *data, size_t len,
     GstBuffer *buffer = gst_buffer_new_allocate(NULL, au_len, NULL);
     if (buffer) {
         gst_buffer_fill(buffer, 0, au, au_len);
-        if (reset_stream) GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DISCONT);
+        if (start_stream) GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DISCONT);
         GstFlowReturn flow = gst_app_src_push_buffer(appsrc, buffer);
         if (flow != GST_FLOW_OK && flow != GST_FLOW_FLUSHING) {
             uv_log_warn("SHM appsrc push returned %s", gst_flow_get_name(flow));
@@ -239,6 +255,11 @@ void shm_ingress_set_appsrc(ShmIngress *si, GstAppSrc *appsrc) {
     if (appsrc) gst_object_ref(appsrc);
     GstAppSrc *old = si->appsrc;
     si->appsrc = appsrc;
+    if (appsrc && appsrc != old) {
+        /* An appsrc belongs to one parser/decoder instance. Never seed a new
+         * instance with inter-predicted frames from the middle of a GOP. */
+        si->waiting_for_idr = TRUE;
+    }
     g_mutex_unlock(&si->lock);
     if (old) gst_object_unref(old);
 }

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -301,7 +301,7 @@ typedef struct {
 } QoSDatabase;
 
 typedef struct {
-    UvIngressMode ingress_mode;
+    int ingress_mode; /* UvIngressMode; int for __atomic ops */
     int payload_type;
     int clock_rate;
     gboolean sync_to_clock;

--- a/src/uv_internal.h
+++ b/src/uv_internal.h
@@ -197,6 +197,7 @@ typedef struct {
     GThread *thread;
     volatile gboolean stop;
     volatile gboolean push_enabled;
+    gboolean waiting_for_idr;
     gboolean stream_reset_pending;
     GMutex lock;
     GstAppSrc *appsrc;
@@ -411,6 +412,7 @@ void     relay_controller_set_push_enabled(RelayController *rc, gboolean enabled
 int      relay_controller_register_shm(RelayController *rc, const char *label);
 void     relay_controller_shm_frame(RelayController *rc, int idx, const uint8_t *au,
                                     size_t len, const VencFrameMeta *meta);
+void     relay_controller_shm_reattached(RelayController *rc, int idx);
 UvSourceKind relay_controller_source_kind(RelayController *rc, int index);
 void     relay_controller_frame_block_configure(RelayController *rc, gboolean enabled, gboolean snapshot_mode);
 void     relay_controller_frame_block_pause(RelayController *rc, gboolean paused);


### PR DESCRIPTION
Supersedes #28 and #27 — combines them into the complete fix for the SHM open/display issue.

## What this branches contains
- **From #28** (init timing + data race): dropdown clear-to-`GTK_INVALID_LIST_POSITION` so re-select fires; Restart Pipeline re-selects via the public `uv_viewer_select_source` (handles UDP↔SHM mode mismatch + rollback); auto-connect of the first discovered source; `__atomic` acquire/release on `pipeline_controller` `ingress_mode` (GTK vs streaming-thread race).
- **Re-grafted from #27** (recovery robustness): ingress-side `waiting_for_idr` gate — a newly bound appsrc or recreated ring drops delta AUs until the first IDR, flushes stale parser/decoder state at that IDR, and marks it DISCONT; `relay_controller_shm_reattached` re-emits `SOURCE_SELECTED` on producer restart so the GUI proactively requests a decoder-bootstrap IDR.

## Why both
#28 fixed the paths that decide whether SHM ever displays but removed #27's IDR gate, regressing recovery: a failed/slow `/api/v1/video/recover` could leave the decoder blank or push deltas into a flushed decoder (invalid-delta flood). This branch keeps #28's flush + HTTP recover as the trigger **and** the ingress gate as the safety net.

## Verification
- Warning-free `make clean && make`.
- Live SigmaStar venc frame-shm over the `jscc-ethernet` bench (external consumer): the viewer auto-connects to `venc_frame_out`, gates to the first IDR, and sustains real-time playback — `decode_errors: 0`, `malformed: 0`, no new `shm_full_drops`, no invalid-delta warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)