### PR TITLE
frame-shm: adopt gdr_pos/gdr_len meta, drop reserved!=0 reject

### DIFF
--- a/include/frame_shm_format.h
+++ b/include/frame_shm_format.h
@@ -24,12 +24,20 @@
 
 #define UV_FRAME_CODEC_H265 0x01u
 #define UV_FRAME_FLAG_IDR 0x01u
+#define UV_FRAME_FLAG_GDR 0x02u     /* GDR rolling intra-refresh stripe active */
+#define UV_FRAME_FLAG_ENHANCE 0x04u /* SVC-T enhance layer (droppable) */
 
+/* Bytes 6-7 were a single "reserved" u16 (producer <= v0.42.x). waybeam_venc
+ * #179 (>= v0.43.0) repurposed them into the GDR cycle position/length, which
+ * are non-zero on every non-IDR frame whenever intra-refresh is active. Older
+ * consumers that rejected reserved != 0 dropped every delta frame; do not
+ * reintroduce that check. */
 typedef struct {
     uint32_t pts;
     uint8_t codec;
     uint8_t flags;
-    uint16_t reserved;
+    uint8_t gdr_pos; /* 0-based position in the GDR cycle (0 when inactive) */
+    uint8_t gdr_len; /* GDR cycle length in frames (0 when inactive) */
 } VencFrameMeta;
 
 _Static_assert(sizeof(VencFrameMeta) == 8, "VencFrameMeta must be 8 bytes");

--- a/src/shm_ingress.c
+++ b/src/shm_ingress.c
@@ -108,7 +108,9 @@ static gboolean backing_object_current(ShmIngress *si) {
 
 static void push_frame(ShmIngress *si, const uint8_t *data, size_t len,
                        const VencFrameMeta *meta) {
-    if (len <= sizeof(*meta) || meta->codec != UV_FRAME_CODEC_H265 || meta->reserved != 0) {
+    /* No reserved-field check: bytes 6-7 now carry gdr_pos/gdr_len (venc #179),
+     * which are non-zero on every non-IDR frame when intra-refresh is on. */
+    if (len <= sizeof(*meta) || meta->codec != UV_FRAME_CODEC_H265) {
         g_mutex_lock(&si->lock);
         si->bad_slots++;
         g_mutex_unlock(&si->lock);


### PR DESCRIPTION
## Problem
With `waybeam_venc` #179 (≥ v0.43.0), radeon-vrx showed **one frame then freeze** in `rally` (and any GDR/intra-refresh-active mode) when consuming the frame-shm ring.

## Root cause
venc #179 repurposed `VencFrameMeta` bytes 6–7 from a single `reserved u16` into `gdr_pos u8 / gdr_len u8`, and added `GDR` (0x02) / `ENHANCE` (0x04) flag bits. These bytes are **non-zero on every non-IDR frame while intra-refresh is on**, so the old `meta->reserved != 0` ingress check (`shm_ingress.c`) dropped every delta frame — only the IDR survived.

## Fix
- `frame_shm_format.h`: `reserved u16` → `gdr_pos u8 / gdr_len u8`; add `UV_FRAME_FLAG_GDR` / `UV_FRAME_FLAG_ENHANCE`.
- `shm_ingress.c`: remove the `reserved != 0` reject.

No decoder changes. The HEVC bitstream (including `TRAIL_N` enhance frames) decodes cleanly on both `avdec_h265` and `vah265dec` — verified by decoding the captured post-link stream (397/397 frames, 0 errors). `ENHANCE` is an out-of-band droppability hint; all frames are still forwarded (full framerate on a clean link).

## Verification (live, against `waybeam-link rx` ring `venc_frame_out`)
| ingress condition | 3 s of live rally |
|---|---|
| old `reserved!=0` reject | `frames=0  bad_slots=198` → one frame |
| **fixed** | `frames=198  bad_slots=0` → full 60 fps |

Canonical wire format documented in coordination `protocols/frame-shm.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)