### PR TITLE
Stop a silent audio sink from stalling the video sink

### DIFF
--- a/src/pipeline_builder.c
+++ b/src/pipeline_builder.c
@@ -245,6 +245,25 @@ static GstPadProbeReturn audio_src_probe(GstPad *pad, GstPadProbeInfo *info, gpo
     return GST_PAD_PROBE_OK;
 }
 
+/* autoaudiosink instantiates its real sink only when it reaches READY, so the
+ * sync/async knobs have to be applied to the child as it appears. Leaving
+ * async=TRUE on a sink that never receives data keeps the whole pipeline's
+ * state change to PLAYING pending, which stalls the video sink too. */
+static void audio_sink_deep_element_added(GstBin *bin, GstBin *sub_bin,
+                                          GstElement *element, gpointer user_data) {
+    (void)bin;
+    (void)sub_bin;
+    (void)user_data;
+    if (!element) return;
+    GObjectClass *klass = G_OBJECT_GET_CLASS(element);
+    if (g_object_class_find_property(klass, "sync")) {
+        g_object_set(element, "sync", FALSE, NULL);
+    }
+    if (g_object_class_find_property(klass, "async")) {
+        g_object_set(element, "async", FALSE, NULL);
+    }
+}
+
 static void remove_audio_probe(PipelineController *pc) {
     if (!pc || pc->audio_probe_id == 0) return;
     if (!pc->audio_resample) {
@@ -715,6 +734,18 @@ static gboolean build_pipeline(PipelineController *pc, GError **error) {
             g_object_set(pc->audio_sink, "sync", FALSE, NULL);
             if (g_object_class_find_property(G_OBJECT_GET_CLASS(pc->audio_sink), "async")) {
                 g_object_set(pc->audio_sink, "async", FALSE, NULL);
+            } else if (GST_IS_BIN(pc->audio_sink)) {
+                /* autoaudiosink is a GstBin: it proxies "sync" but has no
+                 * "async" property, so the guard above silently did nothing
+                 * and its inner sink kept async=TRUE. With no audio on the
+                 * separate UDP port that inner sink never prerolls, the
+                 * pipeline never completes its state change to PLAYING, and
+                 * every other async sink (the video sink) stalls after its
+                 * own preroll buffer -> frozen picture. The real sink only
+                 * exists once the bin reaches READY, so patch it as it is
+                 * added. */
+                g_signal_connect(pc->audio_sink, "deep-element-added",
+                                 G_CALLBACK(audio_sink_deep_element_added), NULL);
             }
         }
     }


### PR DESCRIPTION
## Problem

Enabling audio with **Separate UDP port** freezes the video on the first frame. **Shared with video port** keeps playing.

`autoaudiosink` is a `GstBin`: it proxies `sync` but has **no `async` property** (only `async-handling`). So this guard in `build_pipeline` silently did nothing:

```c
g_object_set(pc->audio_sink, "sync", FALSE, NULL);              // works
if (g_object_class_find_property(..., "async"))                  // NULL on autoaudiosink
    g_object_set(pc->audio_sink, "async", FALSE, NULL);          // never runs
```

The inner `pulsesink` kept `async=TRUE`. With nothing arriving on the separate audio port it never prerolls, the pipeline's state change to PLAYING stays pending, and every other async sink — including the video sink — stalls right after its own preroll buffer.

Shared-port mode escapes this only because `build_pipeline` pushes a silent-Opus primer into the audio **appsrc**, and that push is gated on `!audio_use_separate_port`. `udpsrc` has no equivalent.

Isolated at the GStreamer level: live `videotestsrc` + a dead `udpsrc` audio branch yields **1** buffer with `fakesink sync=false` (async default TRUE) vs **150** with `fakesink sync=false async=false`.

## Fix

Apply `sync`/`async` to the bin's child via `deep-element-added` — the real sink only exists once `autoaudiosink` reaches READY.

`async-handling=TRUE` on the bin also unfreezes video, but it triggers a latency-recalc spin (112k `gst_base_sink_query_latency` calls in 12 s vs 9 normally), so it was discarded.

## Manual test

Synthetic sender on `:5700` video / `:5701` opus, 12 s runs, video-sink renders counted with `GST_DEBUG=basesink:5`:

| Config | Before | After |
|---|---|---|
| `--no-audio` (control) | 332 | — |
| `--audio-port shared` | 334 | 346 |
| `--audio-port 5701`, audio flowing | 882 | plays video + audio |
| `--audio-port 5701`, no audio arriving | **0, stops at 0.498 s** | **342** |

Latency query count stays at 9 in every post-fix case. `make` is clean under `-Wall -Wextra`.

Note: a `fakesink` video sink (`async=FALSE`) masks the bug entirely — it only reproduces with a real video sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)